### PR TITLE
Fix workflow YAML indentation

### DIFF
--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -59,26 +59,26 @@ jobs:
         run: |
           mkdir -p repositories/manifests
           context_lines=$(echo "$COOKIECUTTER_CONTEXT" | jq -r 'to_entries[] | "      \(.key): \"\(.value)\""')
-          cat > repositories/manifests/$REPO_NAME.yaml <<MANIFEST
-apiVersion: v1
-kind: GitHubRepository
-metadata:
-  name: $REPO_NAME
-  createdAt: "$CREATED_AT"
-  createdBy: "$REQUESTED_BY"
-spec:
-  description: "$DESCRIPTION"
-  visibility: "$VISIBILITY"
-  ownerTeam:
-    slug: "$OWNER_TEAM_SLUG"
-    permission: "$OWNER_TEAM_PERMISSION"
-  template:
-    source: "$COOKIECUTTER_TEMPLATE"
-    context:
-$context_lines
-status:
-  phase: creating
-MANIFEST
+            cat > repositories/manifests/$REPO_NAME.yaml <<MANIFEST
+            apiVersion: v1
+            kind: GitHubRepository
+            metadata:
+              name: $REPO_NAME
+              createdAt: "$CREATED_AT"
+              createdBy: "$REQUESTED_BY"
+            spec:
+              description: "$DESCRIPTION"
+              visibility: "$VISIBILITY"
+              ownerTeam:
+                slug: "$OWNER_TEAM_SLUG"
+                permission: "$OWNER_TEAM_PERMISSION"
+              template:
+                source: "$COOKIECUTTER_TEMPLATE"
+                context:
+                $context_lines
+            status:
+              phase: creating
+            MANIFEST
           echo "MANIFEST=repositories/manifests/$REPO_NAME.yaml" >> $GITHUB_ENV
 
       - name: Azure login
@@ -168,29 +168,29 @@ MANIFEST
       - name: Finalize manifest
         run: |
           context_lines=$(echo "$COOKIECUTTER_CONTEXT" | jq -r 'to_entries[] | "      \(.key): \"\(.value)\""')
-          cat > "$MANIFEST" <<MANIFEST
-apiVersion: v1
-kind: GitHubRepository
-metadata:
-  name: $REPO_NAME
-  createdAt: "$CREATED_AT"
-  createdBy: "$REQUESTED_BY"
-spec:
-  description: "$DESCRIPTION"
-  visibility: "$VISIBILITY"
-  ownerTeam:
-    slug: "$OWNER_TEAM_SLUG"
-    permission: "$OWNER_TEAM_PERMISSION"
-  template:
-    source: "$COOKIECUTTER_TEMPLATE"
-    context:
-$context_lines
-status:
-  id: "$repo_id"
-  htmlUrl: "$html_url"
-  sshUrl: "$ssh_url"
-  phase: active
-MANIFEST
+            cat > "$MANIFEST" <<MANIFEST
+            apiVersion: v1
+            kind: GitHubRepository
+            metadata:
+              name: $REPO_NAME
+              createdAt: "$CREATED_AT"
+              createdBy: "$REQUESTED_BY"
+            spec:
+              description: "$DESCRIPTION"
+              visibility: "$VISIBILITY"
+              ownerTeam:
+                slug: "$OWNER_TEAM_SLUG"
+                permission: "$OWNER_TEAM_PERMISSION"
+              template:
+                source: "$COOKIECUTTER_TEMPLATE"
+                context:
+                $context_lines
+            status:
+              id: "$repo_id"
+              htmlUrl: "$html_url"
+              sshUrl: "$ssh_url"
+              phase: active
+            MANIFEST
 
       - name: Commit manifest
         uses: ./.github/actions/commit-yaml

--- a/.github/workflows/create-team.yml
+++ b/.github/workflows/create-team.yml
@@ -112,25 +112,25 @@ jobs:
           members_block=$(echo "$TF_MEMBERS" | jq -r '.[] | "- username: \(.username)\n  role: \(.role)"')
           aliases_block=$(echo "$ALIASES" | jq -r '.[] | "- \(.)"')
           cat > teams/manifests/${TEAM_SLUG}.yaml <<MANIFEST
-apiVersion: v1
-kind: GitHubTeam
-metadata:
-  name: "$TEAM_NAME"
-  slug: "$TEAM_SLUG"
-  createdAt: "$CREATED_AT"
-  createdBy: "$REQUESTED_BY"
-spec:
-  description: "$DESCRIPTION"
-  privacy: "$PRIVACY"
-  parent:
-    slug: "${PARENT_TEAM_SLUG:-null}"
-  members:
-$(if [ -n "$members_block" ]; then echo "$members_block" | sed 's/^/    /'; else echo "    []"; fi)
-  aliases:
-$(if [ -n "$aliases_block" ]; then echo "$aliases_block" | sed 's/^/    /'; else echo "    []"; fi)
-status:
-  phase: creating
-MANIFEST
+            apiVersion: v1
+            kind: GitHubTeam
+            metadata:
+              name: "$TEAM_NAME"
+              slug: "$TEAM_SLUG"
+              createdAt: "$CREATED_AT"
+              createdBy: "$REQUESTED_BY"
+            spec:
+              description: "$DESCRIPTION"
+              privacy: "$PRIVACY"
+              parent:
+                slug: "${PARENT_TEAM_SLUG:-null}"
+              members:
+              $(if [ -n "$members_block" ]; then echo "$members_block" | sed 's/^/    /'; else echo "    []"; fi)
+              aliases:
+              $(if [ -n "$aliases_block" ]; then echo "$aliases_block" | sed 's/^/    /'; else echo "    []"; fi)
+            status:
+              phase: creating
+            MANIFEST
           echo "MANIFEST=teams/manifests/${TEAM_SLUG}.yaml" >> $GITHUB_ENV
 
       - name: Azure login
@@ -164,19 +164,19 @@ MANIFEST
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        run: |
-          cat > members.auto.tfvars.json <<EOF
-{ "members": $TF_MEMBERS }
-EOF
-          terraform apply -auto-approve \
+          run: |
+            cat > members.auto.tfvars.json <<EOF
+            { "members": $TF_MEMBERS }
+            EOF
+            terraform apply -auto-approve \
             -var "org=$GH_ORG" \
             -var "team_name=$TEAM_NAME" \
             -var "privacy=$PRIVACY" \
             -var "description=$DESCRIPTION" \
             -var "parent_team_slug=$PARENT_TEAM_SLUG"
-          terraform output -json > tf.json
-          echo "TEAM_ID=$(jq -r .team_id.value tf.json)" >> $GITHUB_ENV
-          echo "HTML_URL=$(jq -r .html_url.value tf.json)" >> $GITHUB_ENV
+            terraform output -json > tf.json
+            echo "TEAM_ID=$(jq -r .team_id.value tf.json)" >> $GITHUB_ENV
+            echo "HTML_URL=$(jq -r .html_url.value tf.json)" >> $GITHUB_ENV
 
       - name: Upsert entity to Port
         uses: port-labs/port-action@v1
@@ -208,27 +208,27 @@ EOF
           members_block=$(echo "$TF_MEMBERS" | jq -r '.[] | "- username: \(.username)\n  role: \(.role)"')
           aliases_block=$(echo "$ALIASES" | jq -r '.[] | "- \(.)"')
           cat > "$MANIFEST" <<MANIFEST
-apiVersion: v1
-kind: GitHubTeam
-metadata:
-  name: "$TEAM_NAME"
-  slug: "$TEAM_SLUG"
-  createdAt: "$CREATED_AT"
-  createdBy: "$REQUESTED_BY"
-spec:
-  description: "$DESCRIPTION"
-  privacy: "$PRIVACY"
-  parent:
-    slug: "${PARENT_TEAM_SLUG:-null}"
-  members:
-$(if [ -n "$members_block" ]; then echo "$members_block" | sed 's/^/    /'; else echo "    []"; fi)
-  aliases:
-$(if [ -n "$aliases_block" ]; then echo "$aliases_block" | sed 's/^/    /'; else echo "    []"; fi)
-status:
-  id: "$TEAM_ID"
-  htmlUrl: "$HTML_URL"
-  phase: active
-MANIFEST
+            apiVersion: v1
+            kind: GitHubTeam
+            metadata:
+              name: "$TEAM_NAME"
+              slug: "$TEAM_SLUG"
+              createdAt: "$CREATED_AT"
+              createdBy: "$REQUESTED_BY"
+            spec:
+              description: "$DESCRIPTION"
+              privacy: "$PRIVACY"
+              parent:
+                slug: "${PARENT_TEAM_SLUG:-null}"
+              members:
+              $(if [ -n "$members_block" ]; then echo "$members_block" | sed 's/^/    /'; else echo "    []"; fi)
+              aliases:
+              $(if [ -n "$aliases_block" ]; then echo "$aliases_block" | sed 's/^/    /'; else echo "    []"; fi)
+            status:
+              id: "$TEAM_ID"
+              htmlUrl: "$HTML_URL"
+              phase: active
+            MANIFEST
 
       - name: Commit manifest
         uses: ./.github/actions/commit-yaml

--- a/.github/workflows/update-repository.yml
+++ b/.github/workflows/update-repository.yml
@@ -67,30 +67,30 @@ jobs:
             echo "Manifest $MANIFEST_PATH not found" >&2; exit 1; fi
           pip install pyyaml >/dev/null
           python - <<'PY' >> $GITHUB_ENV
-import os, json, yaml
-p=os.environ['MANIFEST_PATH']
-with open(p) as f:
-  data=yaml.safe_load(f)
-meta=data.get('metadata',{})
-spec=data.get('spec',{})
-settings=spec.get('settings',{})
-status=data.get('status',{})
-print(f"EXISTING_DESCRIPTION={spec.get('description','')}")
-print(f"EXISTING_VISIBILITY={spec.get('visibility','')}")
-print(f"EXISTING_HOMEPAGE_URL={spec.get('homepageUrl','') or ''}")
-import json as j
-print(f"EXISTING_TOPICS={j.dumps(spec.get('topics',[]))}")
-print(f"EXISTING_DELETE_BRANCH_ON_MERGE={str(settings.get('deleteBranchOnMerge', True)).lower()}")
-print(f"EXISTING_ENABLE_ISSUES={str(settings.get('enableIssues', True)).lower()}")
-print(f"EXISTING_ENABLE_WIKI={str(settings.get('enableWiki', False)).lower()}")
-print(f"EXISTING_DEFAULT_BRANCH={settings.get('defaultBranch','')}")
-print(f"EXISTING_CUSTOM={j.dumps(spec.get('custom', {}))}")
-print(f"EXISTING_ID={status.get('id','')}")
-print(f"EXISTING_HTML_URL={status.get('htmlUrl','')}")
-print(f"EXISTING_SSH_URL={status.get('sshUrl','')}")
-print(f"EXISTING_CREATED_AT={meta.get('createdAt','')}")
-print(f"EXISTING_CREATED_BY={meta.get('createdBy','')}")
-PY
+            import os, json, yaml
+            p=os.environ['MANIFEST_PATH']
+            with open(p) as f:
+              data=yaml.safe_load(f)
+            meta=data.get('metadata',{})
+            spec=data.get('spec',{})
+            settings=spec.get('settings',{})
+            status=data.get('status',{})
+            print(f"EXISTING_DESCRIPTION={spec.get('description','')}")
+            print(f"EXISTING_VISIBILITY={spec.get('visibility','')}")
+            print(f"EXISTING_HOMEPAGE_URL={spec.get('homepageUrl','') or ''}")
+            import json as j
+            print(f"EXISTING_TOPICS={j.dumps(spec.get('topics',[]))}")
+            print(f"EXISTING_DELETE_BRANCH_ON_MERGE={str(settings.get('deleteBranchOnMerge', True)).lower()}")
+            print(f"EXISTING_ENABLE_ISSUES={str(settings.get('enableIssues', True)).lower()}")
+            print(f"EXISTING_ENABLE_WIKI={str(settings.get('enableWiki', False)).lower()}")
+            print(f"EXISTING_DEFAULT_BRANCH={settings.get('defaultBranch','')}")
+            print(f"EXISTING_CUSTOM={j.dumps(spec.get('custom', {}))}")
+            print(f"EXISTING_ID={status.get('id','')}")
+            print(f"EXISTING_HTML_URL={status.get('htmlUrl','')}")
+            print(f"EXISTING_SSH_URL={status.get('sshUrl','')}")
+            print(f"EXISTING_CREATED_AT={meta.get('createdAt','')}")
+            print(f"EXISTING_CREATED_BY={meta.get('createdBy','')}")
+          PY
 
       - name: Compute desired state
         run: |
@@ -187,20 +187,20 @@ PY
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         run: |
           set -e
-          cat > payload.auto.tfvars.json <<VARS
-{
-  "org": "$GH_ORG",
-  "repo_name": "$REPO_NAME",
-  "description": "$DESCRIPTION",
-  "visibility": "$VISIBILITY",
-  "homepage_url": $HOMEPAGE_URL_JSON,
-  "topics": $TOPICS_FINAL,
-  "delete_branch_on_merge": $DELETE_BRANCH_ON_MERGE,
-  "enable_issues": $ENABLE_ISSUES,
-  "enable_wiki": $ENABLE_WIKI,
-  "default_branch": $DEFAULT_BRANCH_JSON
-}
-VARS
+            cat > payload.auto.tfvars.json <<VARS
+            {
+              "org": "$GH_ORG",
+              "repo_name": "$REPO_NAME",
+              "description": "$DESCRIPTION",
+              "visibility": "$VISIBILITY",
+              "homepage_url": $HOMEPAGE_URL_JSON,
+              "topics": $TOPICS_FINAL,
+              "delete_branch_on_merge": $DELETE_BRANCH_ON_MERGE,
+              "enable_issues": $ENABLE_ISSUES,
+              "enable_wiki": $ENABLE_WIKI,
+              "default_branch": $DEFAULT_BRANCH_JSON
+            }
+            VARS
           terraform plan -out=tfplan -detailed-exitcode >/tmp/plan.log && code=$? || code=$?
           if [ $code -eq 2 ]; then
             echo "TF_HAS_CHANGES=1" >> $GITHUB_ENV
@@ -254,46 +254,46 @@ VARS
           set -e
           pip install pyyaml >/dev/null
           python - <<'PY' >> $GITHUB_ENV
-import os, yaml, json, datetime
-repo=os.environ['REPO_NAME']
-path=f"repositories/manifests/{repo}.yaml"
-if os.path.exists(path):
-  with open(path) as f:
-    data=yaml.safe_load(f)
-else:
-  data={'apiVersion':'v1','kind':'GitHubRepository','metadata':{'name':repo}}
-meta=data.setdefault('metadata',{})
-if os.getenv('EXISTING_CREATED_AT'):
-  meta['createdAt']=os.environ['EXISTING_CREATED_AT']
-if os.getenv('EXISTING_CREATED_BY'):
-  meta['createdBy']=os.environ['EXISTING_CREATED_BY']
-spec=data.setdefault('spec',{})
-spec['description']=os.environ['DESCRIPTION']
-spec['visibility']=os.environ['VISIBILITY']
-spec['homepageUrl']=os.environ.get('HOMEPAGE_URL') or None
-spec['topics']=json.loads(os.environ['TOPICS_FINAL'])
-settings=spec.setdefault('settings',{})
-settings['deleteBranchOnMerge']=os.environ['DELETE_BRANCH_ON_MERGE'].lower()=='true'
-settings['enableIssues']=os.environ['ENABLE_ISSUES'].lower()=='true'
-settings['enableWiki']=os.environ['ENABLE_WIKI'].lower()=='true'
-branch=os.environ.get('DEFAULT_BRANCH')
-settings['defaultBranch']=branch if branch else None
-custom=json.loads(os.environ['CUSTOM_FINAL'])
-if custom:
-  spec['custom']=custom
-elif 'custom' in spec:
-  del spec['custom']
-status=data.setdefault('status',{})
-status['id']=os.environ.get('REPO_ID') or os.environ.get('EXISTING_ID')
-status['htmlUrl']=os.environ.get('HTML_URL') or os.environ.get('EXISTING_HTML_URL')
-status['sshUrl']=os.environ.get('SSH_URL') or os.environ.get('EXISTING_SSH_URL')
-status['phase']='active'
-status['lastUpdatedAt']=datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
-os.makedirs('repositories/manifests', exist_ok=True)
-with open(path,'w') as f:
-  yaml.safe_dump(data,f,sort_keys=False)
-print(f"MANIFEST={path}")
-PY
+            import os, yaml, json, datetime
+            repo=os.environ['REPO_NAME']
+            path=f"repositories/manifests/{repo}.yaml"
+            if os.path.exists(path):
+              with open(path) as f:
+                data=yaml.safe_load(f)
+            else:
+              data={'apiVersion':'v1','kind':'GitHubRepository','metadata':{'name':repo}}
+            meta=data.setdefault('metadata',{})
+            if os.getenv('EXISTING_CREATED_AT'):
+              meta['createdAt']=os.environ['EXISTING_CREATED_AT']
+            if os.getenv('EXISTING_CREATED_BY'):
+              meta['createdBy']=os.environ['EXISTING_CREATED_BY']
+            spec=data.setdefault('spec',{})
+            spec['description']=os.environ['DESCRIPTION']
+            spec['visibility']=os.environ['VISIBILITY']
+            spec['homepageUrl']=os.environ.get('HOMEPAGE_URL') or None
+            spec['topics']=json.loads(os.environ['TOPICS_FINAL'])
+            settings=spec.setdefault('settings',{})
+            settings['deleteBranchOnMerge']=os.environ['DELETE_BRANCH_ON_MERGE'].lower()=='true'
+            settings['enableIssues']=os.environ['ENABLE_ISSUES'].lower()=='true'
+            settings['enableWiki']=os.environ['ENABLE_WIKI'].lower()=='true'
+            branch=os.environ.get('DEFAULT_BRANCH')
+            settings['defaultBranch']=branch if branch else None
+            custom=json.loads(os.environ['CUSTOM_FINAL'])
+            if custom:
+              spec['custom']=custom
+            elif 'custom' in spec:
+              del spec['custom']
+            status=data.setdefault('status',{})
+            status['id']=os.environ.get('REPO_ID') or os.environ.get('EXISTING_ID')
+            status['htmlUrl']=os.environ.get('HTML_URL') or os.environ.get('EXISTING_HTML_URL')
+            status['sshUrl']=os.environ.get('SSH_URL') or os.environ.get('EXISTING_SSH_URL')
+            status['phase']='active'
+            status['lastUpdatedAt']=datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+            os.makedirs('repositories/manifests', exist_ok=True)
+            with open(path,'w') as f:
+              yaml.safe_dump(data,f,sort_keys=False)
+            print(f"MANIFEST={path}")
+          PY
 
       - name: Commit manifest
         uses: ./.github/actions/commit-yaml

--- a/.github/workflows/update-team.yml
+++ b/.github/workflows/update-team.yml
@@ -62,17 +62,17 @@ jobs:
           if [ -f "$MANIFEST_PATH" ]; then
             pip install pyyaml >/dev/null
             python - <<'PY' >> $GITHUB_ENV
-import os, json, yaml
-p=os.environ['MANIFEST_PATH']
-with open(p) as f:
-  data=yaml.safe_load(f)
-print(f"EXISTING_CREATED_AT={data.get('metadata',{}).get('createdAt','')}")
-print(f"EXISTING_CREATED_BY={data.get('metadata',{}).get('createdBy','')}")
-import json as j
-print(f"EXISTING_ALIASES={j.dumps(data.get('spec',{}).get('aliases',[]))}")
-print(f"EXISTING_ID={data.get('status',{}).get('id','')}")
-print(f"EXISTING_HTML_URL={data.get('status',{}).get('htmlUrl','')}")
-PY
+              import os, json, yaml
+              p=os.environ['MANIFEST_PATH']
+              with open(p) as f:
+                data=yaml.safe_load(f)
+              print(f"EXISTING_CREATED_AT={data.get('metadata',{}).get('createdAt','')}")
+              print(f"EXISTING_CREATED_BY={data.get('metadata',{}).get('createdBy','')}")
+              import json as j
+              print(f"EXISTING_ALIASES={j.dumps(data.get('spec',{}).get('aliases',[]))}")
+              print(f"EXISTING_ID={data.get('status',{}).get('id','')}")
+              print(f"EXISTING_HTML_URL={data.get('status',{}).get('htmlUrl','')}")
+            PY
           else
             echo "EXISTING_CREATED_AT=" >> $GITHUB_ENV
             echo "EXISTING_CREATED_BY=" >> $GITHUB_ENV
@@ -182,11 +182,11 @@ PY
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         run: |
           set -e
-          if [ "$TF_MEMBERS" != "null" ]; then
-            cat > members.auto.tfvars.json <<EOF
-{ "members": $TF_MEMBERS }
-EOF
-          else
+            if [ "$TF_MEMBERS" != "null" ]; then
+              cat > members.auto.tfvars.json <<EOF
+              { "members": $TF_MEMBERS }
+              EOF
+            else
             rm -f members.auto.tfvars.json
           fi
           terraform plan -out=tfplan -detailed-exitcode \
@@ -290,28 +290,28 @@ EOF
           members_block=$(echo "$FINAL_MEMBERS" | jq -r '.[] | "- username: \(.username)\n  role: \(.role)"')
           aliases_block=$(echo "$ALIASES_FINAL" | jq -r '.[] | "- \(.)"')
           cat > teams/manifests/${TEAM_SLUG}.yaml <<MANIFEST
-apiVersion: v1
-kind: GitHubTeam
-metadata:
-  name: "$TEAM_NAME"
-  slug: "$TEAM_SLUG"
-$(if [ -n "$EXISTING_CREATED_AT" ]; then echo "  createdAt: \"$EXISTING_CREATED_AT\""; fi)
-$(if [ -n "$EXISTING_CREATED_BY" ]; then echo "  createdBy: \"$EXISTING_CREATED_BY\""; fi)
-spec:
-  description: "$DESCRIPTION"
-  privacy: "$PRIVACY"
-  parent:
-    slug: "${PARENT_TEAM_SLUG:-null}"
-  members:
-$(if [ -n "$members_block" ]; then echo "$members_block" | sed 's/^/    /'; else echo "    []"; fi)
-  aliases:
-$(if [ -n "$aliases_block" ]; then echo "$aliases_block" | sed 's/^/    /'; else echo "    []"; fi)
-status:
-  id: "${TEAM_ID:-$EXISTING_ID}"
-  htmlUrl: "${HTML_URL:-$EXISTING_HTML_URL}"
-  phase: active
-  lastUpdatedAt: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-MANIFEST
+            apiVersion: v1
+            kind: GitHubTeam
+            metadata:
+              name: "$TEAM_NAME"
+              slug: "$TEAM_SLUG"
+            $(if [ -n "$EXISTING_CREATED_AT" ]; then echo "            createdAt: \"$EXISTING_CREATED_AT\""; fi)
+            $(if [ -n "$EXISTING_CREATED_BY" ]; then echo "            createdBy: \"$EXISTING_CREATED_BY\""; fi)
+            spec:
+              description: "$DESCRIPTION"
+              privacy: "$PRIVACY"
+              parent:
+                slug: "${PARENT_TEAM_SLUG:-null}"
+              members:
+            $(if [ -n "$members_block" ]; then echo "$members_block" | sed 's/^/    /'; else echo "    []"; fi)
+              aliases:
+            $(if [ -n "$aliases_block" ]; then echo "$aliases_block" | sed 's/^/    /'; else echo "    []"; fi)
+            status:
+              id: "${TEAM_ID:-$EXISTING_ID}"
+              htmlUrl: "${HTML_URL:-$EXISTING_HTML_URL}"
+              phase: active
+              lastUpdatedAt: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            MANIFEST
 
       - name: Commit manifest
         uses: ./.github/actions/commit-yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,3 +49,4 @@ Below is the breakdown of tasks to be implemented. Each task should be undertake
    - `members_mode: set` manages full membership via Terraform (removes absent users).
    - `members_mode: add`/`remove` adjust memberships incrementally via GitHub API.
    - Non-org users are skipped and reported as warnings back to Port.
+- Resolved YAML syntax issues in workflow here-doc sections to ensure GitHub Actions load correctly.


### PR DESCRIPTION
## Summary
- fix here-doc indentation in workflows
- ensure manifests and terraform blocks parse correctly
- document resolution of YAML issues

## Testing
- `yamllint .github/workflows/create-team.yml .github/workflows/update-team.yml .github/workflows/update-repository.yml .github/workflows/create-repository.yml`
- `python - <<'PY'
import yaml
for path in ['.github/workflows/create-team.yml','.github/workflows/update-team.yml','.github/workflows/update-repository.yml','.github/workflows/create-repository.yml']:
    yaml.safe_load(open(path))
print('done')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689861879a608330bfc1d272de40e42e