### PR TITLE
Add sample workflow_dispatch payloads for local testing

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,15 @@
+# Tests
+
+This directory contains sample `workflow_dispatch` event payloads for simulating Port-triggered workflows using [act](https://github.com/nektos/act).
+
+## Usage
+
+1. Create a `.secrets` file in the repository root with the secrets required by the workflows (e.g. `GH_ORG`, `GH_APP_ID`, `GH_APP_PRIVATE_KEY`, `GH_APP_INSTALLATION_ID`, `PORT_CLIENT_ID`, `PORT_CLIENT_SECRET`, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_RESOURCE_GROUP`, `AZURE_STORAGE_ACCOUNT`, `AZURE_STORAGE_CONTAINER`, etc.).
+
+2. Run a workflow with one of the provided payloads. For example:
+
+```bash
+act -W .github/workflows/create-repository.yml -e tests/payloads/create-repository.json --secret-file .secrets
+```
+
+Swap the workflow and payload paths to test other workflows.

--- a/tests/payloads/add-team-to-repo.json
+++ b/tests/payloads/add-team-to-repo.json
@@ -1,0 +1,6 @@
+{
+  "ref": "refs/heads/main",
+  "inputs": {
+    "port_payload": "{\"runId\":\"R-101\",\"blueprint\":\"githubRepository\",\"requestedBy\":\"user4\",\"properties\":{\"repo_name\":\"existing-repo\",\"team_slug\":\"core-team\",\"permission\":\"maintain\",\"mirror_on_team_manifest\":true,\"note\":\"grant access\"}}"
+  }
+}

--- a/tests/payloads/archive-repository.json
+++ b/tests/payloads/archive-repository.json
@@ -1,0 +1,6 @@
+{
+  "ref": "refs/heads/main",
+  "inputs": {
+    "port_payload": "{\"runId\":\"R-789\",\"blueprint\":\"githubRepository\",\"requestedBy\":\"user3\",\"properties\":{\"repo_name\":\"old-repo\",\"note\":\"cleanup\"}}"
+  }
+}

--- a/tests/payloads/create-repository.json
+++ b/tests/payloads/create-repository.json
@@ -1,0 +1,6 @@
+{
+  "ref": "refs/heads/main",
+  "inputs": {
+    "port_payload": "{\"runId\":\"R-123\",\"blueprint\":\"githubRepository\",\"requestedBy\":\"user1\",\"properties\":{\"repo_name\":\"sample-repo\",\"description\":\"Sample repository\",\"visibility\":\"private\",\"owner_team_slug\":\"core-team\",\"owner_team_permission\":\"maintain\",\"cookiecutter_template\":\"https://github.com/example/template\",\"cookiecutter_context\":{\"project\":\"sample\"}}}"
+  }
+}

--- a/tests/payloads/create-team.json
+++ b/tests/payloads/create-team.json
@@ -1,0 +1,6 @@
+{
+  "ref": "refs/heads/main",
+  "inputs": {
+    "port_payload": "{\"runId\":\"R-201\",\"blueprint\":\"githubTeam\",\"requestedBy\":\"user6\",\"properties\":{\"team_name\":\"Core Team\",\"privacy\":\"closed\",\"description\":\"Core engineers\",\"parent_team_slug\":\"platform\",\"members\":[{\"username\":\"octocat\",\"role\":\"maintainer\"},{\"username\":\"monalisa\",\"role\":\"member\"}],\"alias_slugs\":[\"core\",\"engineering\"]}}"
+  }
+}

--- a/tests/payloads/delete-team.json
+++ b/tests/payloads/delete-team.json
@@ -1,0 +1,6 @@
+{
+  "ref": "refs/heads/main",
+  "inputs": {
+    "port_payload": "{\"runId\":\"R-203\",\"blueprint\":\"githubTeam\",\"requestedBy\":\"user8\",\"properties\":{\"team_slug\":\"old-team\",\"force\":true,\"note\":\"decommission\"}}"
+  }
+}

--- a/tests/payloads/remove-team-from-repo.json
+++ b/tests/payloads/remove-team-from-repo.json
@@ -1,0 +1,6 @@
+{
+  "ref": "refs/heads/main",
+  "inputs": {
+    "port_payload": "{\"runId\":\"R-102\",\"blueprint\":\"githubRepository\",\"requestedBy\":\"user5\",\"properties\":{\"repo_name\":\"existing-repo\",\"team_slug\":\"core-team\",\"mirror_on_team_manifest\":true,\"note\":\"remove access\"}}"
+  }
+}

--- a/tests/payloads/update-repository.json
+++ b/tests/payloads/update-repository.json
@@ -1,0 +1,6 @@
+{
+  "ref": "refs/heads/main",
+  "inputs": {
+    "port_payload": "{\"runId\":\"R-456\",\"blueprint\":\"githubRepository\",\"requestedBy\":\"user2\",\"properties\":{\"repo_name\":\"existing-repo\",\"description\":\"Updated description\",\"visibility\":\"public\",\"homepage_url\":\"https://example.com\",\"topics\":[\"automation\",\"gh\"],\"delete_branch_on_merge\":true,\"enable_issues\":true,\"enable_wiki\":false,\"default_branch\":\"main\",\"custom_properties\":{\"ci\":\"enabled\"}}}"
+  }
+}

--- a/tests/payloads/update-team.json
+++ b/tests/payloads/update-team.json
@@ -1,0 +1,6 @@
+{
+  "ref": "refs/heads/main",
+  "inputs": {
+    "port_payload": "{\"runId\":\"R-202\",\"blueprint\":\"githubTeam\",\"requestedBy\":\"user7\",\"properties\":{\"team_slug\":\"core-team\",\"new_team_name\":\"Core Team\",\"description\":\"Updated core team\",\"privacy\":\"secret\",\"members_mode\":\"add\",\"members\":[{\"username\":\"octocat\",\"role\":\"member\"}],\"parent_team_slug\":\"platform\",\"aliases\":[\"core\",\"engineering\"]}}"
+  }
+}


### PR DESCRIPTION
## Summary
- add sample `workflow_dispatch` event payloads for each workflow under `tests/payloads`
- document how to run workflows locally with `act` in `tests/README.md`

## Testing
- `actionlint`


------
https://chatgpt.com/codex/tasks/task_e_6898a0d3dfe08330871ee9a4962ad3a7