### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,20 @@ jobs:
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
         shell: bash
-      - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color
+      - name: Run actionlint
+        id: actionlint
+        continue-on-error: true
+        run: |
+          curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/testdata/format/sarif_template.txt -o actionlint.sarif.tmpl
+          ${{ steps.get_actionlint.outputs.executable }} -format "$(cat actionlint.sarif.tmpl)" > actionlint.sarif
         shell: bash
+      - name: Upload SARIF to GitHub
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: actionlint.sarif
+      - name: Fail if actionlint found issues
+        if: steps.actionlint.outcome != 'success'
+        run: exit 1
   terraform:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rhysd/actionlint@v1
+      - uses: rhysd/actionlint@v1.7.7
   terraform:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint@v1
+  terraform:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        directory:
+          - repositories/modules/repo
+          - teams/modules/team
+          - repositories
+          - teams
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v2
+      - name: Terraform init
+        run: terraform init -backend=false
+        working-directory: ${{ matrix.directory }}
+      - name: Terraform validate
+        run: terraform validate
+        working-directory: ${{ matrix.directory }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rhysd/actionlint@v1.7.7
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash
   terraform:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           working_directory: ${{ matrix.directory }}
           reporter: github-check
           fail_level: warning
+          tflint_config: 
       - uses: reviewdog/action-terraform-validate@v1
         with:
           workdir: ${{ matrix.directory }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 on:
   push:
     branches: [main]
@@ -13,7 +18,7 @@ jobs:
       - uses: reviewdog/action-actionlint@v1
         with:
           reporter: github-check
-          fail_on_error: true
+          fail_level: warning
 
   terraform:
     runs-on: ubuntu-latest
@@ -30,9 +35,9 @@ jobs:
         with:
           working_directory: ${{ matrix.directory }}
           reporter: github-check
-          fail_on_error: true
+          fail_level: warning
       - uses: reviewdog/action-terraform-validate@v1
         with:
           workdir: ${{ matrix.directory }}
           reporter: github-check
-          fail_on_error: true
+          fail_level: warning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,21 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Download actionlint
-        id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-        shell: bash
-      - name: Run actionlint
-        id: actionlint
-        continue-on-error: true
-        run: |
-          curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/testdata/format/sarif_template.txt -o actionlint.sarif.tmpl
-          ${{ steps.get_actionlint.outputs.executable }} -format "$(cat actionlint.sarif.tmpl)" > actionlint.sarif
-        shell: bash
-      - name: Upload SARIF to GitHub
-        uses: github/codeql-action/upload-sarif@v2
+      - uses: reviewdog/action-actionlint@v1
         with:
-          sarif_file: actionlint.sarif
+          reporter: github-check
+          fail_on_error: true
+
   terraform:
     runs-on: ubuntu-latest
     strategy:
@@ -36,11 +26,13 @@ jobs:
           - teams
     steps:
       - uses: actions/checkout@v4
-      - uses: terraform-linters/setup-tflint@v3
-      - name: Run tflint
-        run: tflint --format sarif > tflint.sarif
-        working-directory: ${{ matrix.directory }}
-      - name: Upload SARIF to GitHub
-        uses: github/codeql-action/upload-sarif@v2
+      - uses: reviewdog/action-tflint@v1
         with:
-          sarif_file: ${{ matrix.directory }}/tflint.sarif
+          working_directory: ${{ matrix.directory }}
+          reporter: github-check
+          fail_on_error: true
+      - uses: reviewdog/action-terraform-validate@v1
+        with:
+          workdir: ${{ matrix.directory }}
+          reporter: github-check
+          fail_on_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,6 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: actionlint.sarif
-      - name: Fail if actionlint found issues
-        if: steps.actionlint.outcome != 'success'
-        run: exit 1
   terraform:
     runs-on: ubuntu-latest
     strategy:
@@ -39,10 +36,11 @@ jobs:
           - teams
     steps:
       - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v2
-      - name: Terraform init
-        run: terraform init -backend=false
+      - uses: terraform-linters/setup-tflint@v3
+      - name: Run tflint
+        run: tflint --format sarif > tflint.sarif
         working-directory: ${{ matrix.directory }}
-      - name: Terraform validate
-        run: terraform validate
-        working-directory: ${{ matrix.directory }}
+      - name: Upload SARIF to GitHub
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ matrix.directory }}/tflint.sarif


### PR DESCRIPTION
## Summary
- add CI workflow to run actionlint
- validate Terraform modules and root directories

## Testing
- `actionlint`
- `terraform init -backend=false && terraform validate` (repositories/modules/repo)
- `terraform init -backend=false && terraform validate` (teams/modules/team)
- `terraform init -backend=false && terraform validate` (repositories)
- `terraform init -backend=false && terraform validate` (teams)


------
https://chatgpt.com/codex/tasks/task_e_6898a3d18fb48330b08fce75e53e9340