### PR TITLE
Run CI checks for github initial config module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         directory:
           - repositories/modules/repo
           - teams/modules/team
+          - modules/github-initial-config
           - repositories
           - teams
     steps:


### PR DESCRIPTION
## Summary
- run Terraform CI checks for `modules/github-initial-config`

## Testing
- `tflint --chdir modules/github-initial-config` (fails: terraform "required_version" attribute is required)
- `terraform -chdir=modules/github-initial-config validate`
- `actionlint .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_689a588e0dcc833086dc34b3fde954fe