### PR TITLE
Log repository configuration mock runs

### DIFF
--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -202,6 +202,11 @@ jobs:
           terraform apply -auto-approve -var owner="${GH_ORG}" -var repo="${REPO_NAME}"
           rm -rf .terraform terraform.tfstate*
 
+      - name: Mock run notice (configuration)
+        if: ${{ inputs.mock == 'true' }}
+        run: |
+          echo "Mock run: skipping repository configuration"
+
       - name: Upsert entity to Port
         if: ${{ inputs.mock == 'false' }}
         uses: port-labs/port-action@v1


### PR DESCRIPTION
## Summary
- log message when repository configuration is skipped in mock mode

## Testing
- `actionlint`


------
https://chatgpt.com/codex/tasks/task_e_689cac54f0bc8330abf47a404617971c