### PR TITLE
Document repository configuration workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ Port catalog updates and run status reporting leverage the official [`port-labs/
 
 Refer to `AGENTS.md` for design decisions and the task list.
 
+## Repository Configuration
+
+Repository templates include `.provisioning/repository-config.yml`, a YAML file
+that defines initial settings such as branch rulesets, default labels, team
+permissions, Actions variables and secrets. The `create-repository` workflow
+parses this file in a **Configure repository** block and applies it using the
+`modules/github-initial-config` Terraform module. The block:
+
+1. Clones the template to read `.provisioning/repository-config.yml`.
+2. Maps any `workflow_secret` references in the file to provided secrets.
+3. Runs the module to create rulesets, labels, team access, variables and
+   secrets.
+4. Removes the local Terraform directory and state files, keeping this
+   configuration state ephemeral.
+
 ## Secrets and Variables
 
 The GitHub Actions workflows rely on several repository secrets (and


### PR DESCRIPTION
## Summary
- describe `.provisioning/repository-config.yml` and its role in applying rulesets, labels, teams, variables and secrets
- mention `modules/github-initial-config` module and the new Configure repository workflow block
- note that Terraform state from configuration is ephemeral and removed

## Testing
- `actionlint`
- `terraform -chdir=repositories/modules/repo init -backend=false`
- `terraform -chdir=repositories/modules/repo validate`
- `tflint --chdir repositories/modules/repo`
- `terraform -chdir=teams/modules/team init -backend=false`
- `terraform -chdir=teams/modules/team validate`
- `tflint --chdir teams/modules/team`
- `terraform -chdir=modules/github-initial-config init -backend=false`
- `terraform -chdir=modules/github-initial-config validate`
- `tflint --chdir modules/github-initial-config`

------
https://chatgpt.com/codex/tasks/task_e_689cc05870c4833080d4a6ca53a45c5f