### PR TITLE
Document Port payload contracts and reference in workflows

### DIFF
--- a/.github/workflows/add-team-to-repo.yml
+++ b/.github/workflows/add-team-to-repo.yml
@@ -1,6 +1,15 @@
 # Inputs:
 #   port_payload: Port JSON payload
 #   mock: When true, skip side-effecting steps (default: false)
+# Port payload keys used (see docs/port-payload-contracts.md):
+# - runId
+# - blueprint
+# - requestedBy
+# - properties.repo_name
+# - properties.team_slug
+# - properties.permission
+# - properties.mirror_on_team_manifest
+# - properties.note
 name: Grant team access to repository
 
 on:

--- a/.github/workflows/archive-repository.yml
+++ b/.github/workflows/archive-repository.yml
@@ -1,6 +1,12 @@
 # Inputs:
 #   port_payload: Port JSON payload
 #   mock: When true, skip side-effecting steps (default: false)
+# Port payload keys used (see docs/port-payload-contracts.md):
+# - runId
+# - blueprint
+# - requestedBy
+# - properties.repo_name
+# - properties.note
 name: Archive GitHub repository
 
 on:

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -1,6 +1,17 @@
 # Inputs:
 #   port_payload: Port JSON payload
 #   mock: When true, skip side-effecting steps (default: false)
+# Port payload keys used (see docs/port-payload-contracts.md):
+# - runId
+# - blueprint
+# - requestedBy
+# - properties.repo_name
+# - properties.description
+# - properties.visibility
+# - properties.owner_team_slug
+# - properties.owner_team_permission
+# - properties.cookiecutter_template
+# - properties.cookiecutter_context
 name: Create repository from template
 
 on:

--- a/.github/workflows/create-team.yml
+++ b/.github/workflows/create-team.yml
@@ -1,6 +1,16 @@
 # Inputs:
 #   port_payload: Port JSON payload
 #   mock: When true, skip side-effecting steps (default: false)
+# Port payload keys used (see docs/port-payload-contracts.md):
+# - runId
+# - blueprint
+# - requestedBy
+# - properties.team_name
+# - properties.privacy
+# - properties.description
+# - properties.parent_team_slug
+# - properties.members
+# - properties.alias_slugs
 name: Create GitHub team
 
 on:

--- a/.github/workflows/delete-team.yml
+++ b/.github/workflows/delete-team.yml
@@ -1,6 +1,13 @@
 # Inputs:
 #   port_payload: Port JSON payload
 #   mock: When true, skip side-effecting steps (default: false)
+# Port payload keys used (see docs/port-payload-contracts.md):
+# - runId
+# - blueprint
+# - requestedBy
+# - properties.team_slug
+# - properties.force
+# - properties.note
 name: Delete GitHub team
 
 on:

--- a/.github/workflows/remove-team-from-repo.yml
+++ b/.github/workflows/remove-team-from-repo.yml
@@ -1,6 +1,14 @@
 # Inputs:
 #   port_payload: Port JSON payload
 #   mock: When true, skip side-effecting steps (default: false)
+# Port payload keys used (see docs/port-payload-contracts.md):
+# - runId
+# - blueprint
+# - requestedBy
+# - properties.repo_name
+# - properties.team_slug
+# - properties.mirror_on_team_manifest
+# - properties.note
 name: Revoke team access from repository
 
 on:

--- a/.github/workflows/update-repository.yml
+++ b/.github/workflows/update-repository.yml
@@ -1,6 +1,20 @@
 # Inputs:
 #   port_payload: Port JSON payload
 #   mock: When true, skip side-effecting steps (default: false)
+# Port payload keys used (see docs/port-payload-contracts.md):
+# - runId
+# - blueprint
+# - requestedBy
+# - properties.repo_name
+# - properties.description
+# - properties.visibility
+# - properties.homepage_url
+# - properties.topics
+# - properties.delete_branch_on_merge
+# - properties.enable_issues
+# - properties.enable_wiki
+# - properties.default_branch
+# - properties.custom_properties
 name: Update GitHub repository
 
 on:

--- a/.github/workflows/update-team.yml
+++ b/.github/workflows/update-team.yml
@@ -1,6 +1,18 @@
 # Inputs:
 #   port_payload: Port JSON payload
 #   mock: When true, skip side-effecting steps (default: false)
+# Port payload keys used (see docs/port-payload-contracts.md):
+# - runId
+# - blueprint
+# - requestedBy
+# - properties.team_slug
+# - properties.new_team_name
+# - properties.description
+# - properties.privacy
+# - properties.members_mode
+# - properties.parent_team_slug
+# - properties.members
+# - properties.aliases
 name: Update GitHub team
 
 on:

--- a/docs/port-payload-contracts.md
+++ b/docs/port-payload-contracts.md
@@ -1,0 +1,87 @@
+# Port payload contracts
+
+This document lists the JSON keys expected in the `port_payload` input for Port-triggered workflows. Each workflow assumes the payload includes the common fields below and may require additional properties under `properties`.
+
+## Common fields
+- `runId` – Port run identifier used for status updates
+- `blueprint` – blueprint of the triggering entity in Port
+- `requestedBy` – user who initiated the action in Port
+
+## Workflow-specific properties
+
+### create-repository.yml
+**Required**
+- `properties.repo_name` – name of the repository to create and manifest file
+- `properties.description` – description of the repository
+- `properties.visibility` – repository visibility (`private`, `internal`, `public`)
+- `properties.owner_team_slug` – slug of the team assigned as owner
+- `properties.owner_team_permission` – permission granted to the owner team
+- `properties.cookiecutter_template` – cookiecutter template used to scaffold the repo
+- `properties.cookiecutter_context` – key/value variables passed to the template
+
+### update-repository.yml
+**Required**
+- `properties.repo_name` – name of the repository to update
+**Optional**
+- `properties.description` – new repository description
+- `properties.visibility` – change repository visibility
+- `properties.homepage_url` – set repository homepage URL
+- `properties.topics` – list of topics to replace existing topics
+- `properties.delete_branch_on_merge` – enable auto-deletion of merged branches
+- `properties.enable_issues` – toggle Issues feature
+- `properties.enable_wiki` – toggle Wiki feature
+- `properties.default_branch` – set default branch name
+- `properties.custom_properties` – map of custom key/values stored in the manifest
+
+### add-team-to-repo.yml
+**Required**
+- `properties.repo_name` – repository receiving the team grant
+- `properties.team_slug` – team to grant access to
+- `properties.permission` – permission level (`pull`, `push`, etc.)
+**Optional**
+- `properties.mirror_on_team_manifest` – when true, also update the team manifest
+- `properties.note` – text appended to commit message and Port log
+
+### remove-team-from-repo.yml
+**Required**
+- `properties.repo_name` – repository from which to remove the team
+- `properties.team_slug` – team whose access is revoked
+**Optional**
+- `properties.mirror_on_team_manifest` – when true, also remove repo from team manifest
+- `properties.note` – text appended to commit message and Port log
+
+### archive-repository.yml
+**Required**
+- `properties.repo_name` – repository to archive
+**Optional**
+- `properties.note` – text appended to commit message and Port log
+
+### create-team.yml
+**Required**
+- `properties.team_name` – display name for the new team
+- `properties.privacy` – team visibility (`closed` or `secret`)
+**Optional**
+- `properties.description` – team description
+- `properties.parent_team_slug` – slug of parent team to nest under
+- `properties.members` – list of `{username, role}` objects for initial members
+- `properties.alias_slugs` – list of additional slugs referencing the team
+
+### update-team.yml
+**Required**
+- `properties.team_slug` – slug of the team to update
+**Optional**
+- `properties.new_team_name` – new display name for the team
+- `properties.description` – new description
+- `properties.privacy` – new visibility (`closed` or `secret`)
+- `properties.members_mode` – how to apply `members` (`set`, `add`, or `remove`)
+- `properties.parent_team_slug` – assign or change parent team
+- `properties.members` – list of `{username, role}` for membership changes
+- `properties.aliases` – list of alias slugs to set on the team
+
+### delete-team.yml
+**Required**
+- `properties.team_slug` – slug of the team to delete
+**Optional**
+- `properties.force` – proceed even if the team still has repository access
+- `properties.note` – text appended to commit message and Port log
+


### PR DESCRIPTION
## Summary
- document required and optional `port_payload` fields for each workflow
- note common fields `runId`, `blueprint` and `requestedBy`
- link workflows to the payload contract and list the keys they use
- describe how each property is used within its workflow

## Testing
- `actionlint`

------
https://chatgpt.com/codex/tasks/task_e_689cc4398bf4833084a3657cc55829fb