### PR TITLE
Use port-github-action in create repository workflow

### DIFF
--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -260,7 +260,7 @@ jobs:
 
       - name: Upsert entity to Port
         if: ${{ inputs.mock == 'false' }}
-        uses: port-labs/port-action@v1
+        uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
           clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
@@ -319,7 +319,7 @@ jobs:
 
       - name: Report failure to Port
         if: ${{ failure() && inputs.mock == 'false' }}
-        uses: port-labs/port-action@v1
+        uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
           clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}


### PR DESCRIPTION
## Summary
- replace deprecated port-action with port-github-action in create-repository workflow

## Testing
- `actionlint .github/workflows/create-repository.yml`


------
https://chatgpt.com/codex/tasks/task_e_689e0b4821e48330b0d5075449cab14a