### PR TITLE
Use owner input and bool mock checks

### DIFF
--- a/.github/actions/get-gh-app-token/README.md
+++ b/.github/actions/get-gh-app-token/README.md
@@ -5,7 +5,7 @@ Composite action to create a GitHub App installation token and export it for sub
 ## Inputs
 - `app_id` – GitHub App ID
 - `private_key` – GitHub App private key
-- `installation_id` – Installation ID
+- `owner` – GitHub organization or user
 
 ## Outputs
 - `token` – The generated installation token

--- a/.github/actions/get-gh-app-token/action.yml
+++ b/.github/actions/get-gh-app-token/action.yml
@@ -7,8 +7,8 @@ inputs:
   private_key:
     description: GitHub App private key
     required: true
-  installation_id:
-    description: GitHub App installation ID
+  owner:
+    description: GitHub organization or user
     required: true
 outputs:
   token:
@@ -22,7 +22,7 @@ runs:
       with:
         app-id: ${{ inputs.app_id }}
         private-key: ${{ inputs.private_key }}
-        installation-id: ${{ inputs.installation_id }}
+        owner: ${{ inputs.owner }}
     - shell: bash
       run: |
         echo "GITHUB_TOKEN=${{ steps.token.outputs.token }}" >> $GITHUB_ENV

--- a/.github/workflows/add-team-to-repo.yml
+++ b/.github/workflows/add-team-to-repo.yml
@@ -73,7 +73,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Mock run notice
-        if: ${{ inputs.mock == 'true' }}
+        if: ${{ inputs.mock }}
         run: |
           echo "Mock run: skipping side-effecting steps"
 
@@ -83,7 +83,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
+          owner: ${{ secrets.GH_ORG }}
 
       - name: Validate repository and team
         run: |
@@ -110,7 +110,7 @@ jobs:
             } >> "$GITHUB_ENV"
 
       - name: Apply permission
-        if: ${{ inputs.mock == 'false' && env.ACTION != 'noop' }}
+        if: ${{ !inputs.mock && env.ACTION != 'noop' }}
         run: |
           for i in 1 2; do
             if gh api --method PUT "/orgs/${GH_ORG}/teams/${TEAM_SLUG}/repos/${GH_ORG}/${REPO_NAME}" -f permission="${PERMISSION}"; then
@@ -123,7 +123,7 @@ jobs:
             done
 
       - name: Verify permission
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         run: |
             final=$(gh api "repos/${GH_ORG}/${REPO_NAME}/teams" -q ".[] | select(.slug==\"${TEAM_SLUG}\") | .permission" || true)
             if [ -z "$final" ]; then
@@ -139,7 +139,7 @@ jobs:
             } >> "$GITHUB_ENV"
 
       - name: Build commit message
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         run: |
           msg="Grant team '${TEAM_SLUG}' '${FINAL_PERMISSION}' on repo '${REPO_NAME}' (via Port)"
           if [ -n "$NOTE" ]; then
@@ -148,7 +148,7 @@ jobs:
           echo "COMMIT_MESSAGE=$msg" >> "$GITHUB_ENV"
 
       - name: Update manifests
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         run: |
           set -euo pipefail
           pip install pyyaml >/dev/null
@@ -177,7 +177,7 @@ jobs:
           PY
 
       - name: Upsert entity to Port
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -193,18 +193,18 @@ jobs:
           logMessage: ${{ env.PORT_MESSAGE }}
 
       - name: Stage team manifest
-        if: ${{ inputs.mock == 'false' && env.MIRROR == 'true' && env.TEAM_CHANGED == '1' }}
+        if: ${{ !inputs.mock && env.MIRROR == 'true' && env.TEAM_CHANGED == '1' }}
         run: git add "${{ env.TEAM_MANIFEST }}"
 
       - name: Commit manifest(s)
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: ./.github/actions/commit-yaml
         with:
           path: ${{ env.REPO_MANIFEST }}
           message: ${{ env.COMMIT_MESSAGE }}
 
       - name: Report failure to Port
-        if: ${{ failure() && inputs.mock == 'false' }}
+        if: ${{ failure() && !inputs.mock }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}

--- a/.github/workflows/archive-repository.yml
+++ b/.github/workflows/archive-repository.yml
@@ -56,7 +56,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Mock run notice
-        if: ${{ inputs.mock == 'true' }}
+        if: ${{ inputs.mock }}
         run: |
           echo "Mock run: skipping side-effecting steps"
 
@@ -125,10 +125,10 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
+          owner: ${{ secrets.GH_ORG }}
 
       - name: Azure login
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -145,7 +145,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Terraform init
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         working-directory: repositories/modules/repo
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
@@ -162,7 +162,7 @@ jobs:
             -backend-config="use_azuread_auth=true"
 
       - name: Terraform plan and apply
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         working-directory: repositories/modules/repo
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
@@ -216,12 +216,12 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Cleanup Terraform
-        if: ${{ always() && inputs.mock == 'false' }}
+        if: ${{ always() && !inputs.mock }}
         working-directory: repositories/modules/repo
         run: rm -rf .terraform terraform.tfstate*
 
       - name: Compute messages
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         run: |
           if [ "$TF_HAS_CHANGES" = "1" ]; then
             MSG="repository archived via Terraform"
@@ -240,7 +240,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Upsert entity to Port
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -261,7 +261,7 @@ jobs:
           logMessage: ${{ env.PORT_MESSAGE }}
 
       - name: Update manifest
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         run: |
           set -e
           pip install pyyaml >/dev/null
@@ -287,14 +287,14 @@ jobs:
           PY
 
       - name: Commit manifest
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: ./.github/actions/commit-yaml
         with:
           path: ${{ env.MANIFEST }}
           message: ${{ env.COMMIT_MESSAGE }}
 
       - name: Report failure to Port
-        if: ${{ failure() && inputs.mock == 'false' }}
+        if: ${{ failure() && !inputs.mock }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -85,7 +85,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Mock run notice
-        if: ${{ inputs.mock == 'true' }}
+        if: ${{ inputs.mock }}
         run: |
           echo "Mock run: skipping side-effecting steps"
 
@@ -95,7 +95,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
+          owner: ${{ secrets.GH_ORG }}
 
       - name: Validate repository name
         run: ./scripts/validate-name.sh "$GH_ORG" "$REPO_NAME"
@@ -127,7 +127,7 @@ jobs:
                     echo "MANIFEST=repositories/manifests/${REPO_NAME}.yaml" >> "$GITHUB_ENV"
 
       - name: Azure login
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -135,7 +135,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Terraform init
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         working-directory: repositories/modules/repo
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
@@ -152,7 +152,7 @@ jobs:
             -backend-config="use_azuread_auth=true"
 
       - name: Terraform apply
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         working-directory: repositories/modules/repo
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
@@ -177,12 +177,12 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Cleanup Terraform
-        if: ${{ always() && inputs.mock == 'false' }}
+        if: ${{ always() && !inputs.mock }}
         working-directory: repositories/modules/repo
         run: rm -rf .terraform terraform.tfstate*
 
       - name: Scaffold repository
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         run: |
@@ -199,7 +199,7 @@ jobs:
           git push origin main
 
       - name: Configure repository
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
           GH_SECRETS: ${{ toJson(secrets) }}
@@ -250,16 +250,16 @@ jobs:
           terraform apply -auto-approve -var owner="${GH_ORG}" -var repo="${REPO_NAME}"
 
       - name: Cleanup Terraform (configuration)
-        if: ${{ always() && inputs.mock == 'false' }}
+        if: ${{ always() && !inputs.mock }}
         run: rm -rf tf-config/.terraform tf-config/terraform.tfstate*
 
       - name: Mock run notice (configuration)
-        if: ${{ inputs.mock == 'true' }}
+        if: ${{ inputs.mock }}
         run: |
           echo "Mock run: skipping repository configuration"
 
       - name: Upsert entity to Port
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -283,7 +283,7 @@ jobs:
           status: success
 
       - name: Finalize manifest
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         run: |
           context_lines=$(echo "$COOKIECUTTER_CONTEXT" | jq -r 'to_entries[] | "      \(.key): \"\(.value)\""')
           cat > "$MANIFEST" <<MANIFEST
@@ -311,14 +311,14 @@ jobs:
           MANIFEST
 
       - name: Commit manifest
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: ./.github/actions/commit-yaml
         with:
           path: ${{ env.MANIFEST }}
           message: Add repository '${{ env.REPO_NAME }}' (automated via Port)
 
       - name: Report failure to Port
-        if: ${{ failure() && inputs.mock == 'false' }}
+        if: ${{ failure() && !inputs.mock }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -329,7 +329,7 @@ jobs:
           logMessage: 'Workflow failed'
 
       - name: Mark manifest failed
-        if: ${{ failure() && inputs.mock == 'false' }}
+        if: ${{ failure() && !inputs.mock }}
         run: |
           if [ -f "$MANIFEST" ]; then
             sed -i 's/phase: creating/phase: failed/' "$MANIFEST"

--- a/.github/workflows/create-team.yml
+++ b/.github/workflows/create-team.yml
@@ -84,7 +84,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Mock run notice
-        if: ${{ inputs.mock == 'true' }}
+        if: ${{ inputs.mock }}
         run: |
           echo "Mock run: skipping side-effecting steps"
 
@@ -94,7 +94,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
+          owner: ${{ secrets.GH_ORG }}
 
       - name: Validate team slug
         run: ./scripts/validate-team-name.sh "$GH_ORG" "$TEAM_SLUG"
@@ -142,7 +142,7 @@ jobs:
           scripts/draft-team-manifest.sh "$TEAM_SLUG" "$TEAM_NAME" "$CREATED_AT" "$REQUESTED_BY" "$DESCRIPTION" "$PRIVACY" "$PARENT_TEAM_SLUG" "$members_formatted" "$aliases_formatted"
 
       - name: Azure login
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -150,7 +150,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Terraform init
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         working-directory: teams/modules/team
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
@@ -167,7 +167,7 @@ jobs:
             -backend-config="use_azuread_auth=true"
 
       - name: Terraform apply
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         working-directory: teams/modules/team
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
@@ -192,12 +192,12 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Cleanup Terraform
-        if: ${{ always() && inputs.mock == 'false' }}
+        if: ${{ always() && !inputs.mock }}
         working-directory: teams/modules/team
         run: rm -rf .terraform terraform.tfstate*
 
       - name: Upsert entity to Port
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -223,7 +223,7 @@ jobs:
           logMessage: ${{ env.PORT_MESSAGE }}
 
       - name: Finalize manifest
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         run: |
           members_block=$(echo "$TF_MEMBERS" | jq -r '.[] | "- username: \(.username)\n  role: \(.role)"')
           aliases_block=$(echo "$ALIASES" | jq -r '.[] | "- \(.)"')
@@ -251,14 +251,14 @@ jobs:
           MANIFEST
 
       - name: Commit manifest
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: ./.github/actions/commit-yaml
         with:
           path: ${{ env.MANIFEST }}
           message: Add team '${{ env.TEAM_SLUG }}' (automated via Port)
 
       - name: Report failure to Port
-        if: ${{ failure() && inputs.mock == 'false' }}
+        if: ${{ failure() && !inputs.mock }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -269,7 +269,7 @@ jobs:
           logMessage: 'Workflow failed'
 
       - name: Mark manifest failed
-        if: ${{ failure() && inputs.mock == 'false' }}
+        if: ${{ failure() && !inputs.mock }}
         run: |
           if [ -f "$MANIFEST" ]; then
             sed -i 's/phase: creating/phase: failed/' "$MANIFEST"

--- a/.github/workflows/delete-team.yml
+++ b/.github/workflows/delete-team.yml
@@ -68,7 +68,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Mock run notice
-        if: ${{ inputs.mock == 'true' }}
+        if: ${{ inputs.mock }}
         run: |
           echo "Mock run: skipping side-effecting steps"
 
@@ -78,10 +78,10 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
+          owner: ${{ secrets.GH_ORG }}
 
       - name: Azure login
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -120,7 +120,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Terraform destroy
-        if: ${{ inputs.mock == 'false' && env.MODE == 'destroy' }}
+        if: ${{ !inputs.mock && env.MODE == 'destroy' }}
         working-directory: teams/modules/team
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
@@ -152,12 +152,12 @@ jobs:
           done
 
       - name: Cleanup Terraform
-        if: ${{ always() && inputs.mock == 'false' && env.MODE == 'destroy' }}
+        if: ${{ always() && !inputs.mock && env.MODE == 'destroy' }}
         working-directory: teams/modules/team
         run: rm -rf .terraform terraform.tfstate*
 
       - name: Verify deletion
-        if: ${{ inputs.mock == 'false' && env.MODE == 'destroy' }}
+        if: ${{ !inputs.mock && env.MODE == 'destroy' }}
         run: |
           set -e
           if gh api "orgs/${GH_ORG}/teams/${TEAM_SLUG}" >/dev/null 2>&1; then
@@ -174,7 +174,7 @@ jobs:
           echo "PORT_MESSAGE=$msg" >> "$GITHUB_ENV"
 
       - name: Clean manifests
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         id: manifests
         run: |
           set -euo pipefail
@@ -209,7 +209,7 @@ jobs:
           echo "team_removed=$removed" >> "$GITHUB_OUTPUT"
 
       - name: Determine commit path
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         run: |
           path="repositories/manifests"
           if [ "${{ steps.manifests.outputs.repos }}" = "[]" ]; then
@@ -218,21 +218,21 @@ jobs:
           echo "COMMIT_PATH=$path" >> "$GITHUB_ENV"
 
       - name: Build commit message
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         run: |
           msg="Delete team '${TEAM_SLUG}' via Terraform (Port)"
           if [ -n "$NOTE" ]; then msg="$msg - $NOTE"; fi
           echo "COMMIT_MSG=$msg" >> "$GITHUB_ENV"
 
       - name: Commit manifests
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: ./.github/actions/commit-yaml
         with:
           path: ${{ env.COMMIT_PATH }}
           message: ${{ env.COMMIT_MSG }}
 
       - name: Delete team in Port
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -245,7 +245,7 @@ jobs:
           logMessage: ${{ env.PORT_MESSAGE }}
 
       - name: Report failure to Port
-        if: ${{ failure() && inputs.mock == 'false' }}
+        if: ${{ failure() && !inputs.mock }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -257,7 +257,7 @@ jobs:
 
   update-port-repos:
     needs: delete
-    if: ${{ inputs.mock == 'false' && needs.delete.outputs.repos != '[]' }}
+    if: ${{ !inputs.mock && needs.delete.outputs.repos != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/remove-team-from-repo.yml
+++ b/.github/workflows/remove-team-from-repo.yml
@@ -68,7 +68,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Mock run notice
-        if: ${{ inputs.mock == 'true' }}
+        if: ${{ inputs.mock }}
         run: |
           echo "Mock run: skipping side-effecting steps"
 
@@ -78,7 +78,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
+          owner: ${{ secrets.GH_ORG }}
 
       - name: Validate repository and team
         run: |
@@ -99,7 +99,7 @@ jobs:
           echo "HAS_ACCESS=$HAS_ACCESS" >> "$GITHUB_ENV"
 
       - name: Revoke access
-        if: ${{ inputs.mock == 'false' && env.HAS_ACCESS == 'true' }}
+        if: ${{ !inputs.mock && env.HAS_ACCESS == 'true' }}
         run: |
           set -euo pipefail
           for i in 1 2; do
@@ -155,7 +155,7 @@ jobs:
           PY
 
       - name: Upsert repository in Port
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -171,7 +171,7 @@ jobs:
           logMessage: ${{ env.PORT_MESSAGE }}
 
       - name: Upsert team in Port
-        if: ${{ inputs.mock == 'false' && env.MIRROR == 'true' }}
+        if: ${{ !inputs.mock && env.MIRROR == 'true' }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -187,18 +187,18 @@ jobs:
           logMessage: ${{ env.PORT_MESSAGE }}
 
       - name: Stage team manifest
-        if: ${{ inputs.mock == 'false' && env.MIRROR == 'true' && env.TEAM_CHANGED == '1' }}
+        if: ${{ !inputs.mock && env.MIRROR == 'true' && env.TEAM_CHANGED == '1' }}
         run: git add "${{ env.TEAM_MANIFEST }}"
 
       - name: Commit manifest(s)
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: ./.github/actions/commit-yaml
         with:
           path: ${{ env.REPO_MANIFEST }}
           message: ${{ env.COMMIT_MESSAGE }}
 
       - name: Report failure to Port
-        if: ${{ failure() && inputs.mock == 'false' }}
+        if: ${{ failure() && !inputs.mock }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}

--- a/.github/workflows/update-repository.yml
+++ b/.github/workflows/update-repository.yml
@@ -84,7 +84,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Mock run notice
-        if: ${{ inputs.mock == 'true' }}
+        if: ${{ inputs.mock }}
         run: |
           echo "Mock run: skipping side-effecting steps"
 
@@ -167,7 +167,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
+          owner: ${{ secrets.GH_ORG }}
 
       - name: Ensure repository and branch exist
         run: |
@@ -178,7 +178,7 @@ jobs:
           fi
 
       - name: Azure login
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -186,7 +186,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Terraform init
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         working-directory: repositories/modules/repo
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
@@ -203,7 +203,7 @@ jobs:
             -backend-config="use_azuread_auth=true"
 
       - name: Terraform plan and apply
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         working-directory: repositories/modules/repo
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
@@ -247,12 +247,12 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Cleanup Terraform
-        if: ${{ always() && inputs.mock == 'false' }}
+        if: ${{ always() && !inputs.mock }}
         working-directory: repositories/modules/repo
         run: rm -rf .terraform terraform.tfstate*
 
       - name: Compute change message
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         run: |
           total=$TF_HAS_CHANGES
           if [ "$total" -eq 0 ]; then
@@ -266,7 +266,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Upsert entity to Port
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -289,7 +289,7 @@ jobs:
           logMessage: ${{ env.PORT_MESSAGE }}
 
       - name: Update manifest
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         run: |
           set -e
           pip install pyyaml >/dev/null
@@ -336,14 +336,14 @@ jobs:
           PY
 
       - name: Commit manifest
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: ./.github/actions/commit-yaml
         with:
           path: ${{ env.MANIFEST }}
           message: Update repository '${{ env.REPO_NAME }}' (automated via Port)
 
       - name: Report failure to Port
-        if: ${{ failure() && inputs.mock == 'false' }}
+        if: ${{ failure() && !inputs.mock }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}

--- a/.github/workflows/update-team.yml
+++ b/.github/workflows/update-team.yml
@@ -78,7 +78,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Mock run notice
-        if: ${{ inputs.mock == 'true' }}
+        if: ${{ inputs.mock }}
         run: |
           echo "Mock run: skipping side-effecting steps"
 
@@ -105,7 +105,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
+          owner: ${{ secrets.GH_ORG }}
 
       - name: Fetch current team
         run: |
@@ -179,7 +179,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Terraform init
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         working-directory: teams/modules/team
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
@@ -196,7 +196,7 @@ jobs:
             -backend-config="use_azuread_auth=true"
 
       - name: Terraform plan and apply
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         working-directory: teams/modules/team
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
@@ -234,12 +234,12 @@ jobs:
           echo "TF_HAS_CHANGES=$TF_HAS_CHANGES" >> "$GITHUB_ENV"
 
       - name: Cleanup Terraform
-        if: ${{ always() && inputs.mock == 'false' }}
+        if: ${{ always() && !inputs.mock }}
         working-directory: teams/modules/team
         run: rm -rf .terraform terraform.tfstate*
 
       - name: Membership changes
-        if: ${{ inputs.mock == 'false' && (env.MEMBERS_MODE == 'add' || env.MEMBERS_MODE == 'remove') }}
+        if: ${{ !inputs.mock && (env.MEMBERS_MODE == 'add' || env.MEMBERS_MODE == 'remove') }}
         run: |
           changes=0
           if [ "${MEMBERS_MODE}" = "add" ]; then
@@ -261,11 +261,11 @@ jobs:
           echo "MEMBERSHIP_CHANGES=$changes" >> "$GITHUB_ENV"
 
       - name: Set membership changes default
-        if: ${{ inputs.mock == 'false' && (env.MEMBERS_MODE == '' || env.MEMBERS_MODE == 'set') }}
+        if: ${{ !inputs.mock && (env.MEMBERS_MODE == '' || env.MEMBERS_MODE == 'set') }}
         run: echo "MEMBERSHIP_CHANGES=0" >> "$GITHUB_ENV"
 
       - name: Gather final membership
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         run: |
           all=$(gh api "orgs/${GH_ORG}/teams/${TEAM_SLUG}/members" --paginate --jq '.[].login')
           json='[]'
@@ -276,7 +276,7 @@ jobs:
           echo "FINAL_MEMBERS=$json" >> "$GITHUB_ENV"
 
       - name: Compute change count and message
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         run: |
           total=$((TF_HAS_CHANGES + MEMBERSHIP_CHANGES))
           if [ -n "$ALIASES_PAYLOAD" ] && [ "$ALIASES_PAYLOAD" != "$EXISTING_ALIASES" ]; then
@@ -299,7 +299,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Upsert entity to Port
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}
@@ -322,7 +322,7 @@ jobs:
           logMessage: ${{ env.PORT_MESSAGE }}
 
       - name: Update manifest
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         run: |
           mkdir -p teams/manifests
           members_block=$(echo "$FINAL_MEMBERS" | jq -r '.[] | "- username: \(.username)\n  role: \(.role)"')
@@ -332,14 +332,14 @@ jobs:
           scripts/draft-update-team-manifest.sh "$TEAM_SLUG" "$TEAM_NAME" "$EXISTING_CREATED_AT" "$EXISTING_CREATED_BY" "$DESCRIPTION" "$PRIVACY" "$PARENT_TEAM_SLUG" "$members_formatted" "$aliases_formatted" "${TEAM_ID:-$EXISTING_ID}" "${HTML_URL:-$EXISTING_HTML_URL}"
 
       - name: Commit manifest
-        if: ${{ inputs.mock == 'false' }}
+        if: ${{ !inputs.mock }}
         uses: ./.github/actions/commit-yaml
         with:
           path: teams/manifests/${{ env.TEAM_SLUG }}.yaml
           message: Update team '${{ env.TEAM_SLUG }}' (settings/membership via Port)
 
       - name: Report failure to Port
-        if: ${{ failure() && inputs.mock == 'false' }}
+        if: ${{ failure() && !inputs.mock }}
         uses: port-labs/port-github-action@v1
         with:
           clientId: ${{ secrets.PORT_CLIENT_ID }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ All workflows reside in `.github/workflows/` and each corresponds to a specific 
   ```yaml
   - name: Get GitHub App token
     uses: ./.github/actions/get-gh-app-token
-    with: { app_id: ..., private_key: ..., installation_id: ... }
+    with: { app_id: ..., private_key: ..., owner: ... }
   ```
 
   The action writes the installation token to both `GITHUB_TOKEN` and `GH_TOKEN` for subsequent steps. **Do not use** the default `GITHUB_TOKEN` for org operations, as it lacks the required permissions.


### PR DESCRIPTION
## Summary
- replace deprecated installation-id with owner in get-gh-app-token composite
- fix mock input comparisons to use booleans so steps run correctly

## Testing
- `actionlint` *(fails: SC2086, SC2001, SC2018 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689e0d24c0e4833094b7c8c5fd191bce