### PR TITLE
Add Terraform setup action to workflows

### DIFF
--- a/.github/workflows/archive-repository.yml
+++ b/.github/workflows/archive-repository.yml
@@ -135,6 +135,10 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Setup Terraform
+        if: ${{ !inputs.mock }}
+        uses: hashicorp/setup-terraform@v3
+
       - name: Confirm repository exists
         run: |
           gh api "repos/${GH_ORG}/${REPO_NAME}" > repo.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           - teams
     steps:
       - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
       - uses: reviewdog/action-tflint@v1
         with:
           working_directory: ${{ matrix.directory }}

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -134,6 +134,10 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Setup Terraform
+        if: ${{ !inputs.mock }}
+        uses: hashicorp/setup-terraform@v3
+
       - name: Terraform init
         if: ${{ !inputs.mock }}
         working-directory: repositories/modules/repo

--- a/.github/workflows/create-team.yml
+++ b/.github/workflows/create-team.yml
@@ -149,6 +149,10 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Setup Terraform
+        if: ${{ !inputs.mock }}
+        uses: hashicorp/setup-terraform@v3
+
       - name: Terraform init
         if: ${{ !inputs.mock }}
         working-directory: teams/modules/team

--- a/.github/workflows/delete-team.yml
+++ b/.github/workflows/delete-team.yml
@@ -88,6 +88,10 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Setup Terraform
+        if: ${{ !inputs.mock }}
+        uses: hashicorp/setup-terraform@v3
+
       - name: Discover existence
         run: |
           set -euo pipefail

--- a/.github/workflows/update-repository.yml
+++ b/.github/workflows/update-repository.yml
@@ -185,6 +185,10 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Setup Terraform
+        if: ${{ !inputs.mock }}
+        uses: hashicorp/setup-terraform@v3
+
       - name: Terraform init
         if: ${{ !inputs.mock }}
         working-directory: repositories/modules/repo

--- a/.github/workflows/update-team.yml
+++ b/.github/workflows/update-team.yml
@@ -178,6 +178,10 @@ jobs:
             echo "ALIASES_FINAL=$ALIASES_FINAL"
           } >> "$GITHUB_ENV"
 
+      - name: Setup Terraform
+        if: ${{ !inputs.mock }}
+        uses: hashicorp/setup-terraform@v3
+
       - name: Terraform init
         if: ${{ !inputs.mock }}
         working-directory: teams/modules/team


### PR DESCRIPTION
## Summary
- setup Terraform using hashicorp/setup-terraform@v3 before any Terraform steps

## Testing
- `actionlint -shellcheck=`

------
https://chatgpt.com/codex/tasks/task_e_689e204164b08330a068d867d5272067