### PR TITLE
Fix cookiecutter invocation for repo scaffolding

### DIFF
--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -192,7 +192,9 @@ jobs:
         run: |
           pip install cookiecutter
           tmpdir=$(mktemp -d)
-          cookiecutter "$COOKIECUTTER_TEMPLATE" --no-input --output-dir "$tmpdir" --extra-context "$COOKIECUTTER_CONTEXT"
+          context_args=$(echo "$COOKIECUTTER_CONTEXT" | jq -r 'to_entries | map("\(.key)=\(.value|@sh)") | join(" ")')
+          eval set -- "$context_args"
+          cookiecutter "$COOKIECUTTER_TEMPLATE" --no-input --output-dir "$tmpdir" "$@"
           generated_dir=$(ls -d "$tmpdir"/*)
           cd "$generated_dir"
           git init

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -244,7 +244,7 @@ variable "secret_values" {
 
   1. Ensure variables listed in Section 7 are defined in `cookiecutter.json`.
   2. Thread into README or metadata files as needed (no hard dependencies for provisioning).
-* Output: cookiecutter generation works with `--no-input` and extra‑context.
+* Output: cookiecutter generation works with `--no-input` and extra context supplied as key/value pairs.
 
 **Task E — Tests & fixtures**
 


### PR DESCRIPTION
## Summary
- pass cookiecutter extra context via positional key/value args
- clarify project doc on cookiecutter extra context

## Testing
- `actionlint .github/workflows/create-repository.yml`
- `cookiecutter /tmp/cc_template --no-input --output-dir /tmp/cc_test "$@"`


------
https://chatgpt.com/codex/tasks/task_e_689e2f91bfac8330a32eec77bd9d26c1