### PR TITLE
Configure git user in repo creation workflow

### DIFF
--- a/.github/actions/get-gh-app-token/README.md
+++ b/.github/actions/get-gh-app-token/README.md
@@ -9,5 +9,6 @@ Composite action to create a GitHub App installation token and export it for sub
 
 ## Outputs
 - `token` – The generated installation token
+- `app-slug` – The GitHub App slug
 
 The action also writes the token to `GITHUB_TOKEN` and `GH_TOKEN` for downstream steps.

--- a/.github/actions/get-gh-app-token/action.yml
+++ b/.github/actions/get-gh-app-token/action.yml
@@ -14,6 +14,9 @@ outputs:
   token:
     description: Installation access token
     value: ${{ steps.token.outputs.token }}
+  app-slug:
+    description: GitHub App slug
+    value: ${{ steps.token.outputs.app-slug }}
 runs:
   using: composite
   steps:

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -97,6 +97,17 @@ jobs:
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ secrets.GH_ORG }}
 
+      - name: Get bot user ID
+        id: get-user-id
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git user
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
       - name: Validate repository name
         run: ./scripts/validate-name.sh "$GH_ORG" "$REPO_NAME"
 


### PR DESCRIPTION
## Summary
- expose GitHub App slug from composite action
- configure git user using app slug when creating repositories

## Testing
- `actionlint` *(fails: shellcheck warnings in other workflows)*

------
https://chatgpt.com/codex/tasks/task_e_689e383c8d788330b1c4c9658058fa10