### PR TITLE
Require cookiecutter template and infer org from context

### DIFF
--- a/.github/workflows/add-team-to-repo.yml
+++ b/.github/workflows/add-team-to-repo.yml
@@ -31,7 +31,7 @@ permissions:
   id-token: write
 
 env:
-  GH_ORG: ${{ secrets.GH_ORG }}
+  GH_ORG: ${{ github.repository_owner }}
 
 jobs:
   add:
@@ -83,7 +83,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ secrets.GH_ORG }}
+          owner: ${{ env.GH_ORG }}
 
       - name: Validate repository and team
         run: |

--- a/.github/workflows/archive-repository.yml
+++ b/.github/workflows/archive-repository.yml
@@ -28,7 +28,7 @@ permissions:
   id-token: write
 
 env:
-  GH_ORG: ${{ secrets.GH_ORG }}
+  GH_ORG: ${{ github.repository_owner }}
 
 jobs:
   archive:
@@ -125,7 +125,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ secrets.GH_ORG }}
+          owner: ${{ env.GH_ORG }}
 
       - name: Azure login
         if: ${{ !inputs.mock }}

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -38,7 +38,7 @@ permissions:
   actions: read
 
 env:
-  GH_ORG: ${{ secrets.GH_ORG }}
+  GH_ORG: ${{ github.repository_owner }}
 
 jobs:
   validation:
@@ -78,7 +78,7 @@ jobs:
             .properties.port_repo_visibility,
             .properties.port_owning_team_slug,
             .properties.port_owner_team_permission,
-            .properties.cookiecutter_template,
+            (.properties.cookiecutter_template | select(type == "string" and length > 0)),
             .properties.cookiecutter_user_context' >/dev/null
 
           PORT_CONTEXT=$(echo "$PAYLOAD" | jq -c '.properties | with_entries(select(.key | startswith("port_")))')
@@ -126,7 +126,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ secrets.GH_ORG }}
+          owner: ${{ env.GH_ORG }}
 
       - name: Get bot user ID
         id: get-user-id
@@ -220,7 +220,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ secrets.GH_ORG }}
+          owner: ${{ env.GH_ORG }}
 
       - name: Azure login
         if: ${{ !inputs.mock }}
@@ -307,19 +307,24 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ secrets.GH_ORG }}
+          owner: ${{ env.GH_ORG }}
 
       - name: Scaffold repository
         if: ${{ !inputs.mock }}
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           pip install cookiecutter
           tmpdir=$(mktemp -d)
           context_args=$(echo "$COOKIECUTTER_CONTEXT" | jq -r 'to_entries | map("\(.key)=\(.value|@sh)") | join(" ")')
           eval set -- "$context_args"
           cookiecutter "$COOKIECUTTER_TEMPLATE" --no-input --output-dir "$tmpdir" "$@"
-          generated_dir=$(ls -d "$tmpdir"/*)
+          generated_dir=$(find "$tmpdir" -mindepth 1 -maxdepth 1 -type d | head -n1)
+          if [ -z "$generated_dir" ]; then
+            echo "Cookiecutter produced no output" >&2
+            exit 1
+          fi
           cd "$generated_dir"
           git init
           git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GH_ORG}/${REPO_NAME}.git"
@@ -345,7 +350,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ secrets.GH_ORG }}
+          owner: ${{ env.GH_ORG }}
 
       - name: Azure login
         if: ${{ !inputs.mock }}
@@ -445,7 +450,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ secrets.GH_ORG }}
+          owner: ${{ env.GH_ORG }}
 
       - name: Finalize manifest
         if: ${{ !inputs.mock }}

--- a/.github/workflows/create-team.yml
+++ b/.github/workflows/create-team.yml
@@ -32,7 +32,7 @@ permissions:
   actions: read
 
 env:
-  GH_ORG: ${{ secrets.GH_ORG }}
+  GH_ORG: ${{ github.repository_owner }}
 
 jobs:
   create:
@@ -94,7 +94,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ secrets.GH_ORG }}
+          owner: ${{ env.GH_ORG }}
 
       - name: Validate team slug
         run: ./scripts/validate-team-name.sh "$GH_ORG" "$TEAM_SLUG"

--- a/.github/workflows/delete-team.yml
+++ b/.github/workflows/delete-team.yml
@@ -29,7 +29,7 @@ permissions:
   id-token: write
 
 env:
-  GH_ORG: ${{ secrets.GH_ORG }}
+  GH_ORG: ${{ github.repository_owner }}
 
 jobs:
   delete:
@@ -78,7 +78,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ secrets.GH_ORG }}
+          owner: ${{ env.GH_ORG }}
 
       - name: Azure login
         if: ${{ !inputs.mock }}

--- a/.github/workflows/remove-team-from-repo.yml
+++ b/.github/workflows/remove-team-from-repo.yml
@@ -30,7 +30,7 @@ permissions:
   id-token: write
 
 env:
-  GH_ORG: ${{ secrets.GH_ORG }}
+  GH_ORG: ${{ github.repository_owner }}
 
 jobs:
   remove:
@@ -78,7 +78,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ secrets.GH_ORG }}
+          owner: ${{ env.GH_ORG }}
 
       - name: Validate repository and team
         run: |

--- a/.github/workflows/update-repository.yml
+++ b/.github/workflows/update-repository.yml
@@ -36,7 +36,7 @@ permissions:
   actions: read
 
 env:
-  GH_ORG: ${{ secrets.GH_ORG }}
+  GH_ORG: ${{ github.repository_owner }}
 
 jobs:
   update:
@@ -167,7 +167,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ secrets.GH_ORG }}
+          owner: ${{ env.GH_ORG }}
 
       - name: Ensure repository and branch exist
         run: |

--- a/.github/workflows/update-team.yml
+++ b/.github/workflows/update-team.yml
@@ -34,7 +34,7 @@ permissions:
   actions: read
 
 env:
-  GH_ORG: ${{ secrets.GH_ORG }}
+  GH_ORG: ${{ github.repository_owner }}
 
 jobs:
   update:
@@ -105,7 +105,7 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ secrets.GH_ORG }}
+          owner: ${{ env.GH_ORG }}
 
       - name: Fetch current team
         run: |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ the following in the repository settings before running the workflows:
 - `GH_APP_ID` – GitHub App identifier used to mint installation tokens
 - `GH_APP_PRIVATE_KEY` – private key for the GitHub App
 - `GH_APP_INSTALLATION_ID` – installation ID of the GitHub App in the organization
-- `GH_ORG` – name of the GitHub organization
 - `AZURE_CLIENT_ID` – Azure AD application (service principal) client ID for OIDC
 - `AZURE_TENANT_ID` – Azure AD tenant ID
 - `AZURE_SUBSCRIPTION_ID` – Azure subscription containing the storage account
@@ -49,6 +48,8 @@ the following in the repository settings before running the workflows:
 - `PORT_CLIENT_ID` – Port OAuth client ID
 - `PORT_CLIENT_SECRET` – Port OAuth client secret
 - `COOKIECUTTER_GIT_AUTH` – (optional) token for private cookiecutter templates
+
+The GitHub organization is derived from the repository owner (`github.repository_owner`), so no separate `GH_ORG` secret is needed.
 
 ### Variables
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,7 @@ run.
 ## Running workflows with `act`
 
 1. Create a `.secrets` file in the repository root with the secrets
-   required by the workflows (e.g. `GH_ORG`, `GH_APP_ID`,
+   required by the workflows (e.g. `GH_APP_ID`,
    `GH_APP_PRIVATE_KEY`, `GH_APP_INSTALLATION_ID`, `PORT_CLIENT_ID`,
    `PORT_CLIENT_SECRET`, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`,
    `AZURE_SUBSCRIPTION_ID`, `AZURE_RESOURCE_GROUP`,


### PR DESCRIPTION
## Summary
- verify `cookiecutter_template` is a non-empty string during payload parsing so earlier validation fails when template is missing
- drop redundant runtime check in scaffold step
- derive GitHub organization from `github.repository_owner` instead of a secret across workflows and update docs

## Testing
- `actionlint` *(fails: shellcheck reported issues in workflow scripts)*
- `terraform -chdir=repositories/modules/repo init -backend=false`
- `terraform -chdir=repositories/modules/repo validate` *(warns: deprecated attribute)*
- `tflint --chdir repositories/modules/repo` *(warns: terraform "required_version" attribute is required)*
- `terraform -chdir=teams/modules/team init -backend=false`
- `terraform -chdir=teams/modules/team validate`
- `tflint --chdir teams/modules/team` *(warns: terraform "required_version" attribute is required)*

------
https://chatgpt.com/codex/tasks/task_e_689eb7703ae08330a9465c9ad81ef955