### PR TITLE
Configure git user in app token action

### DIFF
--- a/.github/actions/get-gh-app-token/README.md
+++ b/.github/actions/get-gh-app-token/README.md
@@ -11,4 +11,4 @@ Composite action to create a GitHub App installation token and export it for sub
 - `token` – The generated installation token
 - `app-slug` – The GitHub App slug
 
-The action also writes the token to `GITHUB_TOKEN` and `GH_TOKEN` for downstream steps.
+The action also writes the token to `GITHUB_TOKEN` and `GH_TOKEN` for downstream steps and configures the git user to the app's bot account.

--- a/.github/actions/get-gh-app-token/action.yml
+++ b/.github/actions/get-gh-app-token/action.yml
@@ -26,7 +26,16 @@ runs:
         app-id: ${{ inputs.app_id }}
         private-key: ${{ inputs.private_key }}
         owner: ${{ inputs.owner }}
-    - shell: bash
+    - name: Export token
+      shell: bash
       run: |
-        echo "GITHUB_TOKEN=${{ steps.token.outputs.token }}" >> $GITHUB_ENV
-        echo "GH_TOKEN=${{ steps.token.outputs.token }}" >> $GITHUB_ENV
+        echo "GITHUB_TOKEN=${{ steps.token.outputs.token }}" >> "$GITHUB_ENV"
+        echo "GH_TOKEN=${{ steps.token.outputs.token }}" >> "$GITHUB_ENV"
+    - name: Configure git user
+      env:
+        GH_TOKEN: ${{ steps.token.outputs.token }}
+      shell: bash
+      run: |
+        user_id=$(gh api "/users/${{ steps.token.outputs.app-slug }}[bot]" --jq .id)
+        git config --global user.name '${{ steps.token.outputs.app-slug }}[bot]'
+        git config --global user.email "${user_id}+${{ steps.token.outputs.app-slug }}[bot]@users.noreply.github.com"

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -128,17 +128,6 @@ jobs:
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ env.GH_ORG }}
 
-      - name: Get bot user ID
-        id: get-user-id
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-
-      - name: Configure git user
-        run: |
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-
       - name: Validate repository name
         run: ./scripts/validate-name.sh "$GH_ORG" "$REPO_NAME"
 


### PR DESCRIPTION
## Summary
- configure git user as part of `get-gh-app-token` composite action
- remove inline git user config from create repository workflow

## Testing
- `actionlint` *(fails: shellcheck issues in other workflows)*
- `actionlint .github/workflows/create-repository.yml`


------
https://chatgpt.com/codex/tasks/task_e_689ec0d91ba083309c6aef8dc9ce78f6