### PR TITLE
Configure git remote with app token

### DIFF
--- a/.github/actions/get-gh-app-token/README.md
+++ b/.github/actions/get-gh-app-token/README.md
@@ -11,4 +11,4 @@ Composite action to create a GitHub App installation token and export it for sub
 - `token` – The generated installation token
 - `app-slug` – The GitHub App slug
 
-The action also writes the token to `GITHUB_TOKEN` and `GH_TOKEN` for downstream steps and configures the git user to the app's bot account.
+The action also writes the token to `GITHUB_TOKEN` and `GH_TOKEN` for downstream steps, configures the git user to the app's bot account, and updates the `origin` remote to authenticate pushes with the token.

--- a/.github/actions/get-gh-app-token/action.yml
+++ b/.github/actions/get-gh-app-token/action.yml
@@ -39,3 +39,7 @@ runs:
         user_id=$(gh api "/users/${{ steps.token.outputs.app-slug }}[bot]" --jq .id)
         git config --global user.name '${{ steps.token.outputs.app-slug }}[bot]'
         git config --global user.email "${user_id}+${{ steps.token.outputs.app-slug }}[bot]@users.noreply.github.com"
+    - name: Configure git remote
+      shell: bash
+      run: |
+        git remote set-url origin "https://x-access-token:${{ steps.token.outputs.token }}@github.com/${GITHUB_REPOSITORY}.git"


### PR DESCRIPTION
## Summary
- update get-gh-app-token action to set git remote URL with the app token
- document remote configuration in action README

## Testing
- `actionlint` *(fails: shellcheck reported existing warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689ef33ddfb08330aeeee76c2deb94e2