### PR TITLE
Use app token for workflow checkout

### DIFF
--- a/.github/actions/get-gh-app-token/action.yml
+++ b/.github/actions/get-gh-app-token/action.yml
@@ -42,4 +42,6 @@ runs:
     - name: Configure git remote
       shell: bash
       run: |
-        git remote set-url origin "https://x-access-token:${{ steps.token.outputs.token }}@github.com/${GITHUB_REPOSITORY}.git"
+        if [ -d .git ]; then
+          git remote set-url origin "https://x-access-token:${{ steps.token.outputs.token }}@github.com/${GITHUB_REPOSITORY}.git"
+        fi

--- a/.github/workflows/add-team-to-repo.yml
+++ b/.github/workflows/add-team-to-repo.yml
@@ -37,10 +37,19 @@ jobs:
   add:
     runs-on: ubuntu-latest
     steps:
+      - name: Get GitHub App token
+        id: app-token
+        uses: ./.github/actions/get-gh-app-token
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ env.GH_ORG }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Parse payload
         run: |
@@ -76,14 +85,6 @@ jobs:
         if: ${{ inputs.mock }}
         run: |
           echo "Mock run: skipping side-effecting steps"
-
-      - name: Get GitHub App token
-        id: app-token
-        uses: ./.github/actions/get-gh-app-token
-        with:
-          app_id: ${{ secrets.GH_APP_ID }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ env.GH_ORG }}
 
       - name: Validate repository and team
         run: |

--- a/.github/workflows/archive-repository.yml
+++ b/.github/workflows/archive-repository.yml
@@ -34,10 +34,19 @@ jobs:
   archive:
     runs-on: ubuntu-latest
     steps:
+      - name: Get GitHub App token
+        id: app-token
+        uses: ./.github/actions/get-gh-app-token
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ env.GH_ORG }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Parse payload
         run: |
@@ -118,14 +127,6 @@ jobs:
               echo "OWNER_TEAM_PERMISSION_VAR=null"
             fi
           } >> "$GITHUB_ENV"
-
-      - name: Get GitHub App token
-        id: app-token
-        uses: ./.github/actions/get-gh-app-token
-        with:
-          app_id: ${{ secrets.GH_APP_ID }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ env.GH_ORG }}
 
       - name: Azure login
         if: ${{ !inputs.mock }}

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -68,10 +68,19 @@ jobs:
           operation: PATCH_RUN
           runId: ${{ env.RUN_ID }}
           logMessage: "Starting validation"
+      - name: Get GitHub App token
+        id: app-token
+        uses: ./.github/actions/get-gh-app-token
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ env.GH_ORG }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Parse payload
         id: parse
@@ -130,14 +139,6 @@ jobs:
         run: |
           echo "Mock run: skipping side-effecting steps"
 
-      - name: Get GitHub App token
-        id: app-token
-        uses: ./.github/actions/get-gh-app-token
-        with:
-          app_id: ${{ secrets.GH_APP_ID }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ env.GH_ORG }}
-
       - name: Validate repository name
         run: ./scripts/validate-name.sh "$GH_ORG" "$REPO_NAME"
 
@@ -169,10 +170,19 @@ jobs:
           operation: PATCH_RUN
           runId: ${{ env.RUN_ID }}
           logMessage: "Starting env-setup"
+      - name: Get GitHub App token
+        id: app-token
+        uses: ./.github/actions/get-gh-app-token
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ env.GH_ORG }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Draft manifest
         id: draft
@@ -226,17 +236,19 @@ jobs:
           operation: PATCH_RUN
           runId: ${{ env.RUN_ID }}
           logMessage: "Starting create-repo"
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Get GitHub App token
+        id: app-token
         uses: ./.github/actions/get-gh-app-token
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ env.GH_ORG }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Azure login
         if: ${{ !inputs.mock }}
@@ -343,17 +355,19 @@ jobs:
           operation: PATCH_RUN
           runId: ${{ env.RUN_ID }}
           logMessage: "Starting scaffold-service"
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Get GitHub App token
+        id: app-token
         uses: ./.github/actions/get-gh-app-token
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ env.GH_ORG }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Scaffold repository
         id: scaffold
@@ -408,17 +422,19 @@ jobs:
           operation: PATCH_RUN
           runId: ${{ env.RUN_ID }}
           logMessage: "Starting configure-repo"
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Get GitHub App token
+        id: app-token
         uses: ./.github/actions/get-gh-app-token
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ env.GH_ORG }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Azure login
         if: ${{ !inputs.mock }}
@@ -516,17 +532,19 @@ jobs:
           operation: PATCH_RUN
           runId: ${{ env.RUN_ID }}
           logMessage: "Starting tidyup"
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Get GitHub App token
+        id: app-token
         uses: ./.github/actions/get-gh-app-token
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ env.GH_ORG }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Finalize manifest
         if: ${{ !inputs.mock }}

--- a/.github/workflows/create-team.yml
+++ b/.github/workflows/create-team.yml
@@ -38,10 +38,19 @@ jobs:
   create:
     runs-on: ubuntu-latest
     steps:
+      - name: Get GitHub App token
+        id: app-token
+        uses: ./.github/actions/get-gh-app-token
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ env.GH_ORG }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Parse payload
         id: parse
@@ -87,14 +96,6 @@ jobs:
         if: ${{ inputs.mock }}
         run: |
           echo "Mock run: skipping side-effecting steps"
-
-      - name: Get GitHub App token
-        id: app-token
-        uses: ./.github/actions/get-gh-app-token
-        with:
-          app_id: ${{ secrets.GH_APP_ID }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ env.GH_ORG }}
 
       - name: Validate team slug
         run: ./scripts/validate-team-name.sh "$GH_ORG" "$TEAM_SLUG"

--- a/.github/workflows/delete-team.yml
+++ b/.github/workflows/delete-team.yml
@@ -39,10 +39,19 @@ jobs:
       run_id: ${{ env.RUN_ID }}
       port_message: ${{ env.PORT_MESSAGE }}
     steps:
+      - name: Get GitHub App token
+        id: app-token
+        uses: ./.github/actions/get-gh-app-token
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ env.GH_ORG }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Parse payload
         run: |
@@ -71,14 +80,6 @@ jobs:
         if: ${{ inputs.mock }}
         run: |
           echo "Mock run: skipping side-effecting steps"
-
-      - name: Get GitHub App token
-        id: app-token
-        uses: ./.github/actions/get-gh-app-token
-        with:
-          app_id: ${{ secrets.GH_APP_ID }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ env.GH_ORG }}
 
       - name: Azure login
         if: ${{ !inputs.mock }}

--- a/.github/workflows/remove-team-from-repo.yml
+++ b/.github/workflows/remove-team-from-repo.yml
@@ -36,10 +36,19 @@ jobs:
   remove:
     runs-on: ubuntu-latest
     steps:
+      - name: Get GitHub App token
+        id: app-token
+        uses: ./.github/actions/get-gh-app-token
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ env.GH_ORG }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Parse payload
         run: |
@@ -71,14 +80,6 @@ jobs:
         if: ${{ inputs.mock }}
         run: |
           echo "Mock run: skipping side-effecting steps"
-
-      - name: Get GitHub App token
-        id: app-token
-        uses: ./.github/actions/get-gh-app-token
-        with:
-          app_id: ${{ secrets.GH_APP_ID }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ env.GH_ORG }}
 
       - name: Validate repository and team
         run: |

--- a/.github/workflows/update-repository.yml
+++ b/.github/workflows/update-repository.yml
@@ -42,10 +42,19 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+      - name: Get GitHub App token
+        id: app-token
+        uses: ./.github/actions/get-gh-app-token
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ env.GH_ORG }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Parse payload
         run: |
@@ -160,14 +169,6 @@ jobs:
             echo "DEFAULT_BRANCH_JSON=$DEFAULT_BRANCH_JSON"
             echo "CUSTOM_FINAL=$CUSTOM"
           } >> "$GITHUB_ENV"
-
-      - name: Get GitHub App token
-        id: app-token
-        uses: ./.github/actions/get-gh-app-token
-        with:
-          app_id: ${{ secrets.GH_APP_ID }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ env.GH_ORG }}
 
       - name: Ensure repository and branch exist
         run: |

--- a/.github/workflows/update-team.yml
+++ b/.github/workflows/update-team.yml
@@ -40,10 +40,19 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+      - name: Get GitHub App token
+        id: app-token
+        uses: ./.github/actions/get-gh-app-token
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ env.GH_ORG }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Parse payload
         id: parse
@@ -98,14 +107,6 @@ jobs:
               echo "EXISTING_HTML_URL="
             } >> "$GITHUB_ENV"
           fi
-
-      - name: Get GitHub App token
-        id: app-token
-        uses: ./.github/actions/get-gh-app-token
-        with:
-          app_id: ${{ secrets.GH_APP_ID }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ env.GH_ORG }}
 
       - name: Fetch current team
         run: |


### PR DESCRIPTION
## Summary
- generate GitHub App token before checkout in workflows
- allow token action to run pre-checkout by guarding remote config

## Testing
- `actionlint` *(warnings: SC2086, SC2001, SC2019, SC2018)*

------
https://chatgpt.com/codex/tasks/task_e_689ef7c55ff08330809da89f9632aaea