### PR TITLE
Add environment module for repository provisioning

### DIFF
--- a/repositories/modules/environment/main.tf
+++ b/repositories/modules/environment/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}
+
+resource "github_repository_environment" "this" {
+  repository  = var.repository
+  environment = var.environment_name
+}
+
+resource "github_actions_environment_secret" "azure_client_id" {
+  repository      = var.repository
+  environment     = github_repository_environment.this.environment
+  secret_name     = "AZURE_CLIENT_ID"
+  plaintext_value = var.managed_identity_client_id
+}

--- a/repositories/modules/environment/outputs.tf
+++ b/repositories/modules/environment/outputs.tf
@@ -1,0 +1,7 @@
+output "environment_id" {
+  value = github_repository_environment.this.id
+}
+
+output "environment_name" {
+  value = github_repository_environment.this.environment
+}

--- a/repositories/modules/environment/variables.tf
+++ b/repositories/modules/environment/variables.tf
@@ -1,0 +1,11 @@
+variable "repository" {
+  type = string
+}
+
+variable "environment_name" {
+  type = string
+}
+
+variable "managed_identity_client_id" {
+  type = string
+}


### PR DESCRIPTION
## Summary
- add Terraform module to manage GitHub repository environments
- support injecting AZURE_CLIENT_ID secret via managed identity client id

## Testing
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_689f3b7f6a9883308db22d42b085f03d