### PR TITLE
Track repository environments in manifests

### DIFF
--- a/.github/workflows/add-environment.yml
+++ b/.github/workflows/add-environment.yml
@@ -151,12 +151,34 @@ jobs:
             -var "environment_name=${{ steps.parse.outputs.environment_type }}" \
             -var "managed_identity_client_id=${{ steps.parse.outputs.managed_identity_client_id }}"
           terraform output -json > tf.json
+      - name: Update repository manifest
+        run: |
+          set -euo pipefail
+          pip install pyyaml >/dev/null
+          REPO_NAME=$(basename "${{ steps.parse.outputs.github_repository }}")
+          ENV_NAME="${{ steps.parse.outputs.environment_type }}"
+          NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          export REPO_NAME ENV_NAME NOW
+          python - <<'PY' >> "$GITHUB_ENV"
+          import os, importlib.util
+          spec = importlib.util.spec_from_file_location('mu', 'scripts/manifest-utils.py')
+          mu = importlib.util.module_from_spec(spec); spec.loader.exec_module(mu)
+          repo=os.environ['REPO_NAME']
+          env=os.environ['ENV_NAME']
+          ts=os.environ['NOW']
+          path=f"repositories/manifests/{repo}.yaml"
+          changed = mu.upsert_repo_environment(path, env, ts)
+          print(f"MANIFEST={path}")
+          print(f"CHANGED={'1' if changed else '0'}")
+          print(f"COMMIT_MESSAGE=Add environment '{env}' to repo '{repo}'")
+          PY
 
-      - name: Commit workflow changes
+      - name: Commit manifest
+        if: ${{ env.CHANGED == '1' }}
         uses: ./.github/actions/commit-yaml
         with:
-          path: .
-          message: "Record environment workflow changes"
+          path: ${{ env.MANIFEST }}
+          message: ${{ env.COMMIT_MESSAGE }}
 
       - name: Report success to Port
         if: ${{ success() }}

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -234,6 +234,7 @@ jobs:
             ownerTeam:
               slug: "$OWNING_TEAM_SLUG"
               permission: "$OWNER_TEAM_PERMISSION"
+            environments: []
             template:
               source: "$COOKIECUTTER_TEMPLATE"
               context:
@@ -659,6 +660,7 @@ jobs:
             ownerTeam:
               slug: "$OWNING_TEAM_SLUG"
               permission: "$OWNER_TEAM_PERMISSION"
+            environments: []
             template:
               source: "$COOKIECUTTER_TEMPLATE"
               context:

--- a/repositories/manifests/testpr-infra21.yaml
+++ b/repositories/manifests/testpr-infra21.yaml
@@ -2,14 +2,16 @@ apiVersion: v1
 kind: GitHubRepository
 metadata:
   name: testpr-infra21
-  createdAt: "2025-08-15T09:22:36Z"
-  createdBy: "matt@v1vhm.onmicrosoft.com"
+  createdAt: '2025-08-15T09:22:36Z'
+  createdBy: matt@v1vhm.onmicrosoft.com
 spec:
   description: "infra21"
   visibility: "public"
   ownerTeam:
     slug: "cloud-platform-team"
     permission: "push"
+  environments:
+  - "dev"
   template:
     source: "https://github.com/v1vhm/template-terraform-service"
     context:
@@ -24,7 +26,8 @@ spec:
       port_owning_team_slug: "cloud-platform-team"
       port_owner_team_permission: "push"
 status:
-  id: "R_kgDOPeX0IA"
+  id: R_kgDOPeX0IA
   htmlUrl: "https://github.com/v1vhm/testpr-infra21"
   sshUrl: "git@github.com:v1vhm/testpr-infra21.git"
   phase: active
+  lastUpdatedAt: "2024-01-01T00:00:00Z"

--- a/scripts/manifest-utils.py
+++ b/scripts/manifest-utils.py
@@ -68,6 +68,17 @@ def remove_team_repo(team_path, repo_name, timestamp):
     _write(team_path, data)
     return True
 
+def upsert_repo_environment(repo_path, env_name, timestamp):
+    """Add an environment to a repository manifest and touch lastUpdatedAt."""
+    data = _read(repo_path)
+    spec = data.setdefault("spec", {})
+    envs = spec.setdefault("environments", [])
+    if env_name in envs:
+        return False
+    envs.append(env_name)
+    touch_last_updated(repo_path, timestamp, data)
+    return True
+
 def touch_last_updated(path, timestamp, data=None):
     """Update status.lastUpdatedAt on a manifest."""
     data = data if data is not None else _read(path)


### PR DESCRIPTION
## Summary
- support adding environment names to repo manifests via `upsert_repo_environment`
- record environment additions after Terraform apply in `add-environment` workflow
- include `environments` array in repository manifests and example `testpr-infra21`

## Testing
- `actionlint`
- `terraform -chdir=repositories/modules/environment init -backend=false`
- `terraform -chdir=repositories/modules/environment validate`
- `tflint --chdir repositories/modules/environment` *(fails: terraform "required_version" attribute is required)*

------
https://chatgpt.com/codex/tasks/task_e_689f3f8ec37c8330958b1e324b947b7c