### PR TITLE
Document add-environment payload contract

### DIFF
--- a/docs/port-payload-contracts.md
+++ b/docs/port-payload-contracts.md
@@ -92,3 +92,18 @@ The repository name is derived as `<port_product_identifier>-<port_service_ident
 - `properties.force` – proceed even if the team still has repository access
 - `properties.note` – text appended to commit message and Port log
 
+### add-environment.yml
+**Required**
+- `github_repository` – repository receiving the environment
+- `environment_identifier` – name of the environment to create
+- `service_identifier` – service linked to the environment
+- `environment_location` – deployment region for the environment
+- `environment_resource_group` – Azure resource group backing the environment
+- `managed_identity_client_id` – client ID for the managed identity
+- `request_identifier` – Port request identifier
+- `environment_type` – type of environment (`development`, `production`, etc.)
+**Optional**
+- `state_file_container` – Azure storage container for Terraform state
+- `state_file_resource_group` – resource group for Terraform state
+- `state_file_storage_account` – storage account for Terraform state
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,6 +22,14 @@ run.
        --secret-file .secrets
    ```
 
+   To test the add-environment workflow:
+
+   ```bash
+   act -W .github/workflows/add-environment.yml \
+       -e tests/payloads/add-environment.json \
+       --secret-file .secrets
+   ```
+
 3. To execute a "mock" run that skips external calls, append
    `--dryrun`:
 

--- a/tests/payloads/add-environment.json
+++ b/tests/payloads/add-environment.json
@@ -1,0 +1,6 @@
+{
+  "ref": "refs/heads/main",
+  "inputs": {
+    "port_payload": "{\"runId\":\"R-401\",\"request_identifier\":\"REQ-401\",\"github_repository\":\"my-org/sample-repo\",\"environment_identifier\":\"dev\",\"service_identifier\":\"svc1\",\"environment_location\":\"westeurope\",\"environment_resource_group\":\"rg-dev\",\"managed_identity_client_id\":\"11111111-2222-3333-4444-555555555555\",\"environment_type\":\"development\",\"state_file_container\":\"tfstate\",\"state_file_resource_group\":\"rg-state\",\"state_file_storage_account\":\"statestorage\"}"
+  }
+}


### PR DESCRIPTION
## Summary
- document Port payload fields for add-environment workflow
- add sample add-environment payload for local testing
- describe how to invoke add-environment with act

## Testing
- `actionlint`
- `terraform -chdir=repositories/modules/repo init -backend=false`
- `terraform -chdir=repositories/modules/repo validate`
- `tflint --chdir repositories/modules/repo` *(fails: terraform "required_version" attribute is required)*
- `terraform -chdir=teams/modules/team init -backend=false`
- `terraform -chdir=teams/modules/team validate`
- `tflint --chdir teams/modules/team` *(fails: terraform "required_version" attribute is required)*
- `terraform -chdir=repositories/modules/environment init -backend=false`
- `terraform -chdir=repositories/modules/environment validate`
- `tflint --chdir repositories/modules/environment` *(fails: terraform "required_version" attribute is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a81b624188833082d13a22a38d0705