### PR TITLE
Pass repo owner to environment Terraform

### DIFF
--- a/.github/workflows/add-environment.yml
+++ b/.github/workflows/add-environment.yml
@@ -207,6 +207,7 @@ jobs:
         working-directory: repositories/modules/environment
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+          GITHUB_OWNER: ${{ env.GH_ORG }}
           ARM_USE_OIDC: true
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -222,6 +223,7 @@ jobs:
         working-directory: repositories/modules/environment
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+          GITHUB_OWNER: ${{ env.GH_ORG }}
           ARM_USE_OIDC: true
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -232,7 +234,8 @@ jobs:
           terraform apply -auto-approve \
             -var "repository=${{ steps.parse.outputs.github_repository }}" \
             -var "environment_name=${{ steps.parse.outputs.environment_identifier }}" \
-            -var "managed_identity_client_id=${{ steps.parse.outputs.managed_identity_client_id }}"
+            -var "managed_identity_client_id=${{ steps.parse.outputs.managed_identity_client_id }}" \
+            -var "owner=${{ env.GH_ORG }}"
           terraform output -json > tf.json
       - name: Update repository manifest
         shell: bash

--- a/repositories/modules/environment/.terraform.lock.hcl
+++ b/repositories/modules/environment/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.6.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:Fp0RrNe+w167AQkVUWC1WRAsyjhhHN7aHWUky7VkKW8=",
+    "zh:0b1b5342db6a17de7c71386704e101be7d6761569e03fb3ff1f3d4c02c32d998",
+    "zh:2fb663467fff76852126b58315d9a1a457e3b04bec51f04bf1c0ddc9dfbb3517",
+    "zh:4183e557a1dfd413dae90ca4bac37dbbe499eae5e923567371f768053f977800",
+    "zh:48b2979f88fb55cdb14b7e4c37c44e0dfbc21b7a19686ce75e339efda773c5c2",
+    "zh:5d803fb06625e0bcf83abb590d4235c117fa7f4aa2168fa3d5f686c41bc529ec",
+    "zh:6f1dd094cbab36363583cda837d7ca470bef5f8abf9b19f23e9cd8b927153498",
+    "zh:772edb5890d72b32868f9fdc0a9a1d4f4701d8e7f8acb37a7ac530d053c776e3",
+    "zh:798f443dbba6610431dcef832047f6917fb5a4e184a3a776c44e6213fb429cc6",
+    "zh:cc08dfcc387e2603f6dbaff8c236c1254185450d6cadd6bad92879fe7e7dbce9",
+    "zh:d5e2c8d7f50f91d6847ddce27b10b721bdfce99c1bbab42a68fa271337d73d63",
+    "zh:e69a0045440c706f50f84a84ff8b1df520ec9bf757de4b8f9959f2ed20c3f440",
+    "zh:efc5358573a6403cbea3a08a2fcd2407258ac083d9134c641bdcb578966d8bdf",
+    "zh:f627a255e5809ec2375f79949c79417847fa56b9e9222ea7c45a463eb663f137",
+    "zh:f7c02f762e4cf1de7f58bde520798491ccdd54a5bd52278d579c146d1d07d4f0",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/repositories/modules/environment/main.tf
+++ b/repositories/modules/environment/main.tf
@@ -7,6 +7,10 @@ terraform {
   }
 }
 
+provider "github" {
+  owner = var.owner
+}
+
 resource "github_repository_environment" "this" {
   repository  = var.repository
   environment = var.environment_name

--- a/repositories/modules/environment/variables.tf
+++ b/repositories/modules/environment/variables.tf
@@ -9,3 +9,7 @@ variable "environment_name" {
 variable "managed_identity_client_id" {
   type = string
 }
+
+variable "owner" {
+  type = string
+}


### PR DESCRIPTION
## Summary
- expose repository owner to Terraform in add-environment workflow
- configure environment module to accept GitHub owner

## Testing
- `terraform init -backend=false`
- `terraform validate`
- `actionlint .github/workflows/add-environment.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a82bd7fc9c8330a7beb7b897a4a748