### PR TITLE
Fix repo name variable in environment workflow

### DIFF
--- a/.github/workflows/add-environment.yml
+++ b/.github/workflows/add-environment.yml
@@ -232,7 +232,7 @@ jobs:
         run: |
           set -euo pipefail; IFS=$'\n\t'
           terraform apply -auto-approve \
-            -var "repository=${{ steps.parse.outputs.github_repository }}" \
+            -var "repository=${{ env.REPO_NAME }}" \
             -var "environment_name=${{ steps.parse.outputs.environment_identifier }}" \
             -var "managed_identity_client_id=${{ steps.parse.outputs.managed_identity_client_id }}" \
             -var "owner=${{ env.GH_ORG }}"


### PR DESCRIPTION
## Summary
- Use derived repository name when applying environment Terraform

## Testing
- `actionlint .github/workflows/add-environment.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a82dc4c0cc83308d3c592d397c9041