### PR TITLE
Use service identifier for environment state key

### DIFF
--- a/.github/workflows/add-environment.yml
+++ b/.github/workflows/add-environment.yml
@@ -162,7 +162,7 @@ jobs:
             else
               echo "# container_name       = \"\""
             fi
-            echo "key                  = \"${{ steps.parse.outputs.environment_identifier }}.tfstate\""
+            echo "key                  = \"${{ steps.parse.outputs.service_identifier }}.tfstate\""
           } > "$env_dir/${{ steps.parse.outputs.environment_identifier }}.state.config"
           cat > "$env_dir/${{ steps.parse.outputs.environment_identifier }}.tfvars" <<EOF
           environment    = "${{ steps.parse.outputs.environment_identifier }}"


### PR DESCRIPTION
## Summary
- ensure environment state config uses service identifier for backend key

## Testing
- `actionlint .github/workflows/add-environment.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a83ef5a8f08330b3a4601dd1ce0474