### PR TITLE
Explicitly stage environment files in add-environment workflow

### DIFF
--- a/.github/workflows/add-environment.yml
+++ b/.github/workflows/add-environment.yml
@@ -176,7 +176,8 @@ jobs:
         run: |
           set -euo pipefail; IFS=$'\n\t'
           cd service-repo
-          git add env/${{ steps.parse.outputs.environment_identifier }}
+          git add env/${{ steps.parse.outputs.environment_identifier }}/${{ steps.parse.outputs.environment_identifier }}.tfvars
+          git add -f env/${{ steps.parse.outputs.environment_identifier }}/${{ steps.parse.outputs.environment_identifier }}.state.config
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else


### PR DESCRIPTION
## Summary
- ensure add-environment workflow explicitly stages tfvars and state config files when committing environment changes

## Testing
- `actionlint .github/workflows/add-environment.yml`
- `actionlint` *(fails: shellcheck reported issues in other workflows)*
- `terraform -chdir=repositories/modules/repo init -backend=false`
- `terraform -chdir=repositories/modules/repo validate`
- `tflint --chdir repositories/modules/repo` *(fails: terraform "required_version" attribute is required)*
- `terraform -chdir=teams/modules/team init -backend=false`
- `terraform -chdir=teams/modules/team validate`
- `tflint --chdir teams/modules/team` *(fails: terraform "required_version" attribute is required)*


------
https://chatgpt.com/codex/tasks/task_e_68a8523a82d483308240a2d910af6325