### PR TITLE
Add plan/apply environments in environment module

### DIFF
--- a/repositories/modules/environment/main.tf
+++ b/repositories/modules/environment/main.tf
@@ -11,14 +11,20 @@ provider "github" {
   owner = var.owner
 }
 
+locals {
+  phases = ["plan", "apply"]
+}
+
 resource "github_repository_environment" "this" {
+  for_each    = toset(local.phases)
   repository  = var.repository
-  environment = var.environment_name
+  environment = "${var.environment_name}-${each.key}"
 }
 
 resource "github_actions_environment_secret" "azure_client_id" {
+  for_each        = github_repository_environment.this
   repository      = var.repository
-  environment     = github_repository_environment.this.environment
+  environment     = each.value.environment
   secret_name     = "AZURE_CLIENT_ID"
   plaintext_value = var.managed_identity_client_id
 }

--- a/repositories/modules/environment/outputs.tf
+++ b/repositories/modules/environment/outputs.tf
@@ -1,7 +1,7 @@
-output "environment_id" {
-  value = github_repository_environment.this.id
+output "environment_ids" {
+  value = { for k, env in github_repository_environment.this : k => env.id }
 }
 
-output "environment_name" {
-  value = github_repository_environment.this.environment
+output "environment_names" {
+  value = { for k, env in github_repository_environment.this : k => env.environment }
 }


### PR DESCRIPTION
## Summary
- support multiple environments (plan and apply) via `for_each`
- expose environment IDs and names as maps keyed by phase

## Testing
- `terraform fmt`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68a8b6040a1c8330960d6f242502e72d